### PR TITLE
Add QA support helper and Express usage example

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { getAnswer } = require('./support');
+
+const app = express();
+app.use(express.json());
+
+// POST /ask route to fetch answers based on the question provided
+app.post('/ask', (req, res) => {
+  const { question } = req.body;
+  const answer = getAnswer(question);
+  res.json({ answer });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/support.js
+++ b/src/support.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+// Path to the JSON file with question/answer pairs
+const qaFilePath = path.join(__dirname, '..', 'data', 'qa_pairs.json');
+
+// Load and parse the JSON data once when this module is required
+let qaPairs = [];
+try {
+  const rawData = fs.readFileSync(qaFilePath, 'utf-8');
+  qaPairs = JSON.parse(rawData);
+} catch (error) {
+  // If file reading or JSON parsing fails, log the error and keep an empty dataset
+  console.error('Error loading QA pairs:', error);
+}
+
+/**
+ * Returns the answer for a given question.
+ * @param {string} question - The exact question to search for in the dataset.
+ * @returns {string} - The answer if found, otherwise a default message.
+ */
+function getAnswer(question) {
+  const match = qaPairs.find((item) => item.Question === question);
+  return match ? match.Answer : 'Извините, я пока не знаю ответа на этот вопрос.';
+}
+
+module.exports = {
+  getAnswer,
+};


### PR DESCRIPTION
## Summary
- add support module that reads QA pairs and exposes `getAnswer`
- show Express `/ask` route using support helper

## Testing
- `node -e "const { getAnswer } = require('./src/support'); console.log('type', typeof getAnswer); console.log(getAnswer('Пример вопроса'));"`

------
https://chatgpt.com/codex/tasks/task_e_689662580f1c83248f07ea48dcf1a9bb