### PR TITLE
feat: add OpenAI fallback for unanswered questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "express": "^4.18.2",
-        "fuse.js": "^6.6.2"
+        "fuse.js": "^6.6.2",
+        "openai": "^5.12.2"
       }
     },
     "node_modules/accepts": {
@@ -156,6 +158,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -554,6 +568,27 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
+      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "echo \"No tests defined\" && exit 0"
   },
   "dependencies": {
+    "dotenv": "^17.2.1",
     "express": "^4.18.2",
-    "fuse.js": "^6.6.2"
+    "fuse.js": "^6.6.2",
+    "openai": "^5.12.2"
   }
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,22 +1,24 @@
 const express = require('express');
 const { getAnswer } = require('../support/support');
+const logger = require('../utils/logger');
 
 const app = express();
 app.use(express.json());
 
-app.post('/ask', (req, res) => {
+app.post('/ask', async (req, res) => {
   const { question } = req.body || {};
-  const answer = getAnswer(question);
-  if (typeof answer === 'string') {
-    res.json({ answer, source: 'local' });
-  } else {
-    res.json({ answer: 'Извините, пока не знаю. Веду поиск…', source: 'none' });
+  try {
+    const { answer, source } = await getAnswer(question);
+    res.json({ answer, source });
+  } catch (error) {
+    logger.error('Error handling /ask', error);
+    res.status(500).json({ error: 'Internal server error' });
   }
 });
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+  logger.log(`Server listening on port ${PORT}`);
 });
 
 module.exports = app;

--- a/src/llm/fallback.js
+++ b/src/llm/fallback.js
@@ -1,0 +1,34 @@
+const OpenAI = require('openai');
+const dotenv = require('dotenv');
+const logger = require('../utils/logger');
+
+dotenv.config();
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function fallbackQuery(question) {
+  if (!question) {
+    return '';
+  }
+  try {
+    const completion = await client.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a helpful support bot. Use provided QA context when possible.'
+        },
+        { role: 'user', content: question }
+      ],
+      temperature: 0.2,
+      max_tokens: 500
+    });
+    const answer = completion.choices[0]?.message?.content || '';
+    return answer.trim();
+  } catch (error) {
+    logger.error('OpenAI fallback failed', error);
+    throw error;
+  }
+}
+
+module.exports = { fallbackQuery };


### PR DESCRIPTION
## Summary
- add OpenAI-based fallback query utility
- return answer source and call fallback when no local match
- improve ask API to await answers and handle errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689665c149a4832496af89d7f560d73b