### PR TITLE
feat: add moderation flow and OpenAI caching

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -31,7 +31,10 @@ app.post('/ask', async (req, res) => {
     metrics.recordRequest(durationMs, result.source);
     if (result.source === 'openai') {
       metrics.recordNoMatch(question);
-      log.info({ source: result.source, method: result.method, durationMs });
+      if (result.pendingId) {
+        metrics.recordOpenaiCached();
+      }
+      log.info({ source: result.source, method: result.method, durationMs, pendingId: result.pendingId });
     } else {
       log.info({
         source: result.source,
@@ -47,6 +50,7 @@ app.post('/ask', async (req, res) => {
       method: result.method,
       matchedQuestion: result.matchedQuestion,
       score: result.score,
+      pendingId: result.pendingId,
       durationMs
     });
   } catch (error) {

--- a/src/search/fuzzySearch.js
+++ b/src/search/fuzzySearch.js
@@ -2,11 +2,11 @@ const Fuse = require('fuse.js');
 const fuseConfig = require('./fuseConfig');
 const store = require('../data/store');
 
-let data = store.getAll();
+let data = store.getApproved();
 let fuse = new Fuse(data, fuseConfig);
 
 store.onUpdated(() => {
-  data = store.getAll();
+  data = store.getApproved();
   fuse = new Fuse(data, fuseConfig);
 });
 

--- a/src/support/support.js
+++ b/src/support/support.js
@@ -1,6 +1,10 @@
+const crypto = require('crypto');
 const { fuzzySearch } = require('../search/fuzzySearch');
 const { fallbackQuery } = require('../llm/fallback');
 const { logger } = require('../utils/logger');
+const store = require('../data/store');
+
+const OPENAI_MODEL = 'gpt-3.5-turbo';
 
 async function getAnswer(question) {
   if (!question) {
@@ -27,7 +31,26 @@ async function getAnswer(question) {
       };
     }
     const answer = await fallbackQuery(question);
-    return { answer, source: 'openai', method: 'openai' };
+    let pendingId;
+    if (process.env.AUTO_CACHE_OPENAI !== '0') {
+      try {
+        const requestHash = crypto
+          .createHash('sha1')
+          .update(`${question}\n${answer}`)
+          .digest('hex');
+        const pending = await store.addPending({
+          Question: question,
+          Answer: answer,
+          source: 'openai',
+          meta: { model: OPENAI_MODEL, requestHash }
+        });
+        pendingId = pending.id;
+        logger.info({ id: pendingId }, 'Cached OpenAI answer as pending');
+      } catch (err) {
+        logger.error({ err }, 'Failed to cache OpenAI answer');
+      }
+    }
+    return { answer, source: 'openai', method: 'openai', pendingId };
   } catch (error) {
     logger.error({ err: error }, 'Error in getAnswer');
     throw error;

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -1,11 +1,13 @@
 const fs = require('fs');
 const path = require('path');
+const store = require('../data/store');
 
 const counters = {
   totalRequests: 0,
   localHits: 0,
   openaiHits: 0,
-  noMatch: 0
+  noMatch: 0,
+  openaiCached: 0
 };
 
 const timings = {
@@ -38,13 +40,22 @@ function recordNoMatch(question) {
   fs.appendFileSync(path.join(dir, 'no_match.jsonl'), line);
 }
 
+function recordOpenaiCached() {
+  counters.openaiCached += 1;
+}
+
 function snapshot() {
   const avgDurationMs = timings.count ? timings.totalDurationMs / timings.count : 0;
+  const pendingTotal = store
+    .getAll()
+    .filter((i) => i.status === 'pending').length;
   return {
     totalRequests: counters.totalRequests,
     localHits: counters.localHits,
     openaiHits: counters.openaiHits,
     noMatch: counters.noMatch,
+    openaiCached: counters.openaiCached,
+    pendingTotal,
     avgDurationMs,
     maxDurationMs: timings.maxDurationMs
   };
@@ -53,5 +64,6 @@ function snapshot() {
 module.exports = {
   recordRequest,
   recordNoMatch,
+  recordOpenaiCached,
   snapshot
 };


### PR DESCRIPTION
## Summary
- extend data store with moderation statuses and pending dedup
- cache OpenAI fallback answers as pending items and track metrics
- add admin moderation routes with approve/reject logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966c6afa88832489b3cc978caed0f9