### PR TITLE
feat: add hybrid semantic search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,16 @@ MATRIX_RATE_MAX=60
 
 # ----- Internal admin API token used by integrations
 OPERATOR_API_TOKEN=operator-internal-token
+
+# ---- Semantic / embeddings
+SEM_ENABLED=1
+SEM_PROVIDER=local_xenova
+SEM_MODEL_LOCAL=Xenova/all-MiniLM-L6-v2
+OPENAI_EMBED_MODEL=text-embedding-3-small
+SEM_INDEX_PATH=./data/semantic
+SEM_TOPK=5
+SEM_ALPHA=0.7
+SEM_MIN_SIM=0.60
+SEM_REBUILD_ON_START=1
+SEM_BATCH_SIZE=64
+SEM_CACHE=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@xenova/transformers": "^2.17.2",
         "accept-language-parser": "^1.5.0",
         "airtable": "^0.12.1",
         "ajv": "^8.12.0",
@@ -24,8 +25,10 @@
         "fuse.js": "^6.6.2",
         "googleapis": "^136.0.0",
         "helmet": "^7.0.0",
+        "hnswlib-node": "^3.0.0",
         "ipaddr.js": "^2.1.0",
         "matrix-bot-sdk": "^0.7.1",
+        "ml-distance": "^4.0.1",
         "mustache": "^4.2.0",
         "node-cron": "^3.0.3",
         "openai": "^5.12.2",
@@ -727,6 +730,15 @@
         "lodash.uniq": "^4.5.0"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1203,6 +1215,70 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
@@ -1395,6 +1471,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1463,6 +1545,20 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1845,6 +1941,12 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "license": "MIT"
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -1977,6 +2079,78 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
+      "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2053,6 +2227,21 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bintrees": {
@@ -2376,6 +2565,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2448,6 +2643,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2465,6 +2673,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -2741,6 +2959,21 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -2754,6 +2987,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -2791,6 +3033,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3226,6 +3477,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -3338,6 +3598,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3385,6 +3651,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -3724,6 +3996,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3837,6 +4115,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
@@ -3978,6 +4262,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hnswlib-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hnswlib-node/-/hnswlib-node-3.0.0.tgz",
+      "integrity": "sha512-fypn21qvVORassppC8/qNfZ5KAOspZpm/IbUkAtlqvbtDNnF5VVk5RWF7O5V6qwr7z+T3s1ePej6wQt5wRQ4Cg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^8.0.0"
       }
     },
     "node_modules/hpagent": {
@@ -4228,6 +4523,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -4236,6 +4537,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -5422,6 +5729,12 @@
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lowdb": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
@@ -5631,6 +5944,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5668,6 +5993,57 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ml-array-mean": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
+      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-sum": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
+      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-distance": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ml-distance/-/ml-distance-4.0.1.tgz",
+      "integrity": "sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-mean": "^1.1.6",
+        "ml-distance-euclidean": "^2.0.0",
+        "ml-tree-similarity": "^1.0.0"
+      }
+    },
+    "node_modules/ml-distance-euclidean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
+      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==",
+      "license": "MIT"
+    },
+    "node_modules/ml-tree-similarity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz",
+      "integrity": "sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search": "^1.3.5",
+        "num-sort": "^2.0.0"
       }
     },
     "node_modules/mock-fs": {
@@ -5741,6 +6117,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5755,6 +6137,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-cron": {
@@ -5844,6 +6247,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/num-sort": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
+      "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/oauth-sign": {
@@ -5940,6 +6355,56 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/openai": {
       "version": "5.12.2",
@@ -6246,6 +6711,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -6285,6 +6756,44 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
       }
     },
     "node_modules/pretty-bytes": {
@@ -6385,6 +6894,32 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/proxy-addr": {
@@ -6500,6 +7035,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -6884,7 +7443,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6958,6 +7516,35 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7060,6 +7647,66 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7196,6 +7843,19 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.3"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -7406,6 +8066,31 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -7444,6 +8129,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thread-stream": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "load:ask": "node test/load/autocannon.ask.js",
     "docker:build": "docker build -t my-support-bot:latest .",
     "docker:run": "docker run --rm -p 3000:3000 --env-file .env -v $PWD/data:/app/data -v $PWD/logs:/app/logs -v $PWD/feedback:/app/feedback my-support-bot:latest",
-    "metrics:print": "curl -s localhost:${PORT:-3000}${PROM_METRICS_PATH:-/metrics/prom}"
+    "metrics:print": "curl -s localhost:${PORT:-3000}${PROM_METRICS_PATH:-/metrics/prom}",
+    "sem:rebuild": "node -e \"require('./src/semantic/index').rebuildAll().then(console.log).catch(console.error)\""
   },
   "dependencies": {
     "accept-language-parser": "^1.5.0",
@@ -30,12 +31,15 @@
     "express-rate-limit": "^7.0.0",
     "fast-deep-equal": "^3.1.3",
     "fuse.js": "^6.6.2",
+    "hnswlib-node": "^3.0.0",
     "googleapis": "^136.0.0",
     "helmet": "^7.0.0",
     "ipaddr.js": "^2.1.0",
     "matrix-bot-sdk": "^0.7.1",
+    "ml-distance": "^4.0.1",
     "mustache": "^4.2.0",
     "node-cron": "^3.0.3",
+    "@xenova/transformers": "^2.17.2",
     "openai": "^5.12.2",
     "pino": "^9.8.0",
     "pino-elasticsearch": "^8.1.0",

--- a/src/semantic/embedder.js
+++ b/src/semantic/embedder.js
@@ -1,0 +1,139 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { logger } = require('../utils/logger');
+
+const providerName = process.env.SEM_PROVIDER || 'local_xenova';
+const modelLocal = process.env.SEM_MODEL_LOCAL || 'Xenova/all-MiniLM-L6-v2';
+const openaiModel = process.env.OPENAI_EMBED_MODEL || 'text-embedding-3-small';
+const batchSize = parseInt(process.env.SEM_BATCH_SIZE || '64', 10);
+const cacheEnabled = process.env.SEM_CACHE === '1';
+const indexPath = process.env.SEM_INDEX_PATH || path.join(__dirname, '..', '..', 'data', 'semantic');
+const cacheFile = path.join(indexPath, 'cache.jsonl');
+
+let embedder = null;
+const cache = new Map();
+let cacheLoaded = false;
+
+function sha1(text) {
+  return crypto.createHash('sha1').update(text).digest('hex');
+}
+
+function vecToBase64(vec) {
+  const buf = Buffer.from(new Float32Array(vec).buffer);
+  return buf.toString('base64');
+}
+
+function base64ToVec(str) {
+  const buf = Buffer.from(str, 'base64');
+  const arr = new Float32Array(buf.buffer, buf.byteOffset, buf.length / 4);
+  return Array.from(arr);
+}
+
+function loadCache() {
+  if (!cacheEnabled || cacheLoaded) return;
+  cacheLoaded = true;
+  try {
+    if (!fs.existsSync(cacheFile)) return;
+    const lines = fs.readFileSync(cacheFile, 'utf8').split('\n');
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const { t, v } = JSON.parse(line);
+        cache.set(t, base64ToVec(v));
+      } catch (err) {
+        logger.warn({ err }, 'Failed to parse semantic cache line');
+      }
+    }
+  } catch (err) {
+    logger.error({ err }, 'Failed to load semantic cache');
+  }
+}
+
+function appendCache(hash, vector) {
+  if (!cacheEnabled) return;
+  try {
+    const line = JSON.stringify({ t: hash, v: vecToBase64(vector) }) + '\n';
+    fs.appendFileSync(cacheFile, line);
+  } catch (err) {
+    logger.error({ err }, 'Failed to append semantic cache');
+  }
+}
+
+async function initEmbedder() {
+  if (embedder) return embedder;
+  loadCache();
+  if (providerName === 'local_xenova') {
+    try {
+      const { pipeline } = require('@xenova/transformers');
+      embedder = await pipeline('feature-extraction', modelLocal);
+      logger.info({ provider: providerName, model: modelLocal }, 'Semantic embedder initialized');
+    } catch (err) {
+      logger.error({ err }, 'Failed to init local embedder');
+      throw err;
+    }
+  } else if (providerName === 'openai') {
+    try {
+      const OpenAI = require('openai');
+      const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      embedder = { client };
+      logger.info({ provider: providerName, model: openaiModel }, 'Semantic embedder initialized');
+    } catch (err) {
+      logger.error({ err }, 'Failed to init OpenAI embedder');
+      throw err;
+    }
+  } else {
+    throw new Error(`Unknown SEM_PROVIDER: ${providerName}`);
+  }
+  return embedder;
+}
+
+function normalize(vec) {
+  const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+  return vec.map((v) => v / norm);
+}
+
+async function embed(texts = []) {
+  if (!Array.isArray(texts) || texts.length === 0) return [];
+  await initEmbedder();
+  const results = [];
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    if (providerName === 'local_xenova') {
+      // Process sequentially to respect memory limits
+      for (const text of batch) {
+        const hash = sha1(text);
+        if (cache.has(hash)) {
+          results.push(cache.get(hash));
+          continue;
+        }
+        const output = await embedder(text, { pooling: 'mean', normalize: true });
+        const vec = Array.from(output.data || output);
+        cache.set(hash, vec);
+        appendCache(hash, vec);
+        results.push(vec);
+      }
+    } else {
+      // OpenAI provider supports batching
+      const { client } = embedder;
+      try {
+        const resp = await client.embeddings.create({ model: openaiModel, input: batch });
+        for (let j = 0; j < resp.data.length; j++) {
+          const text = batch[j];
+          const hash = sha1(text);
+          let vec = resp.data[j].embedding || [];
+          vec = normalize(vec);
+          cache.set(hash, vec);
+          appendCache(hash, vec);
+          results.push(vec);
+        }
+      } catch (err) {
+        logger.error({ err }, 'OpenAI embedding failed');
+        throw err;
+      }
+    }
+  }
+  return results;
+}
+
+module.exports = { initEmbedder, embed };

--- a/src/semantic/index.js
+++ b/src/semantic/index.js
@@ -1,0 +1,156 @@
+const fs = require('fs');
+const path = require('path');
+const { HierarchicalNSW } = require('hnswlib-node');
+const { embed, initEmbedder } = require('./embedder');
+const { logger } = require('../utils/logger');
+const store = require('../data/store');
+
+const INDEX_PATH = process.env.SEM_INDEX_PATH || path.join(__dirname, '..', '..', 'data', 'semantic');
+const INDEX_FILE = path.join(INDEX_PATH, 'index.bin');
+const META_FILE = path.join(INDEX_PATH, 'meta.json');
+const TOPK = Number(process.env.SEM_TOPK || '5');
+
+let index = null;
+let idToIdx = new Map();
+let idxToId = [];
+let dim = 0;
+let rebuilding = false;
+let rebuildTimer = null;
+
+function ensureDir() {
+  fs.mkdirSync(INDEX_PATH, { recursive: true });
+}
+
+function metaPath() {
+  return META_FILE;
+}
+
+async function rebuildAll() {
+  if (rebuilding) return status();
+  rebuilding = true;
+  try {
+    await initEmbedder();
+    ensureDir();
+    const items = store.getApproved();
+    if (items.length === 0) {
+      index = null;
+      idToIdx = new Map();
+      idxToId = [];
+      dim = 0;
+      fs.writeFileSync(metaPath(), JSON.stringify({ dim: 0, size: 0, updatedAt: new Date().toISOString(), version: 1, ids: [] }, null, 2));
+      return { count: 0, dim: 0 };
+    }
+    const texts = items.map((item) => {
+      const arr = [item.Question];
+      if (item.translations) {
+        for (const t of Object.values(item.translations)) {
+          if (t && t.Question) arr.push(t.Question);
+        }
+      }
+      return arr.join('\n');
+    });
+    const vectors = await embed(texts);
+    dim = vectors[0].length;
+    index = new HierarchicalNSW('cosine', dim);
+    index.initIndex(vectors.length);
+    idxToId = [];
+    idToIdx = new Map();
+    vectors.forEach((vec, i) => {
+      index.addPoint(vec, i);
+      const id = items[i].id;
+      idxToId[i] = id;
+      idToIdx.set(id, i);
+    });
+    index.writeIndexSync(INDEX_FILE);
+    const meta = {
+      dim,
+      size: vectors.length,
+      updatedAt: new Date().toISOString(),
+      version: 1,
+      approvedCount: items.length,
+      ids: idxToId
+    };
+    fs.writeFileSync(metaPath(), JSON.stringify(meta, null, 2));
+    logger.info({ size: vectors.length, dim }, 'Semantic index rebuilt');
+    return { count: vectors.length, dim };
+  } catch (err) {
+    logger.error({ err }, 'Semantic rebuild failed');
+    throw err;
+  } finally {
+    rebuilding = false;
+  }
+}
+
+async function initSemantic(storeInst = store) {
+  ensureDir();
+  if (
+    process.env.SEM_REBUILD_ON_START === '1' ||
+    !fs.existsSync(INDEX_FILE) ||
+    !fs.existsSync(metaPath())
+  ) {
+    await rebuildAll();
+  } else {
+    try {
+      const meta = JSON.parse(fs.readFileSync(metaPath(), 'utf8'));
+      idxToId = meta.ids || [];
+      idToIdx = new Map(idxToId.map((id, i) => [id, i]));
+      dim = meta.dim;
+      index = new HierarchicalNSW('cosine', dim);
+      index.readIndexSync(INDEX_FILE, meta.size);
+      logger.info({ size: meta.size, dim }, 'Semantic index loaded');
+    } catch (err) {
+      logger.error({ err }, 'Failed to load semantic index, rebuilding');
+      await rebuildAll();
+    }
+  }
+  storeInst.onUpdated(() => scheduleRebuild());
+  return status();
+}
+
+function scheduleRebuild() {
+  if (rebuildTimer) return;
+  rebuildTimer = setTimeout(async () => {
+    rebuildTimer = null;
+    try {
+      await rebuildAll();
+    } catch (err) {
+      logger.error({ err }, 'Scheduled semantic rebuild failed');
+    }
+  }, 1000);
+}
+
+async function searchSemantic(query, k = TOPK) {
+  if (!index || idxToId.length === 0) return [];
+  const [vec] = await embed([query]);
+  if (!vec) return [];
+  const result = index.searchKnn(vec, Math.min(k, idxToId.length));
+  const neighbors = result.neighbors || result[0] || [];
+  const distances = result.distances || result[1] || [];
+  const out = [];
+  for (let i = 0; i < neighbors.length; i++) {
+    const id = idxToId[neighbors[i]];
+    const sim = 1 - distances[i];
+    out.push({ id, sim });
+  }
+  return out;
+}
+
+function status() {
+  let updatedAt = null;
+  try {
+    if (fs.existsSync(metaPath())) {
+      updatedAt = JSON.parse(fs.readFileSync(metaPath(), 'utf8')).updatedAt;
+    }
+  } catch (err) {
+    logger.error({ err }, 'Failed to read semantic meta');
+  }
+  return {
+    enabled: process.env.SEM_ENABLED === '1',
+    provider: process.env.SEM_PROVIDER || 'local_xenova',
+    size: idxToId.length,
+    dim,
+    updatedAt
+  };
+}
+
+module.exports = { initSemantic, searchSemantic, rebuildAll, status };

--- a/src/semantic/rerank.js
+++ b/src/semantic/rerank.js
@@ -1,0 +1,33 @@
+const alpha = Number(process.env.SEM_ALPHA || '0.7');
+const MIN_SIM = Number(process.env.SEM_MIN_SIM || '0.6');
+
+function hybridRank({ query, fuzzyResults = [], semResults = [], alpha: a = alpha }) {
+  const candidates = new Map();
+
+  for (const { item, score } of fuzzyResults) {
+    if (!item || !item.id) continue;
+    const entry = candidates.get(item.id) || { item };
+    entry.fuzzy_score = typeof score === 'number' ? score : 1;
+    candidates.set(item.id, entry);
+  }
+
+  for (const { id, sim } of semResults) {
+    const entry = candidates.get(id) || { item: null };
+    entry.sem_sim = sim;
+    entry.sem_score = typeof sim === 'number' ? 1 - sim : 1;
+    if (!entry.item) entry.item = { id };
+    candidates.set(id, entry);
+  }
+
+  const arr = [];
+  for (const entry of candidates.values()) {
+    const fs = entry.fuzzy_score !== undefined ? entry.fuzzy_score : 1;
+    const ss = entry.sem_score !== undefined ? entry.sem_score : 1;
+    entry.combined = a * ss + (1 - a) * fs;
+    arr.push(entry);
+  }
+  arr.sort((a, b) => a.combined - b.combined);
+  return arr;
+}
+
+module.exports = { hybridRank, MIN_SIM };

--- a/src/support/support.js
+++ b/src/support/support.js
@@ -4,6 +4,7 @@ const { fuzzySearch } = require('../search/fuzzySearch');
 const { fallbackQuery } = require('../llm/fallback');
 const { logger } = require('../utils/logger');
 const store = require('../data/store');
+const metrics = require('../utils/metrics');
 const { detectLang } = require('../i18n/detect');
 const {
   selectLocalizedQA,
@@ -13,12 +14,22 @@ const {
 } = require('../i18n/renderer');
 const { liveBus } = require('../live/bus');
 
+const SEM_ENABLED = process.env.SEM_ENABLED === '1';
+let searchSemantic;
+let hybridRank;
+let MIN_SIM;
+if (SEM_ENABLED) {
+  ({ searchSemantic } = require('../semantic/index'));
+  ({ hybridRank, MIN_SIM } = require('../semantic/rerank'));
+}
+
 const OPENAI_MODEL = 'gpt-3.5-turbo';
 const DEFAULT_LANG = process.env.DEFAULT_LANG || 'en';
 const SUPPORTED_LANGS = (process.env.SUPPORTED_LANGS || 'en')
   .split(',')
   .map((l) => l.trim().toLowerCase())
   .filter(Boolean);
+const TOPK = Number(process.env.SEM_TOPK || '5');
 
 async function getAnswer(question, opts = {}) {
   const { lang: explicitLang, vars, acceptLanguageHeader } = opts || {};
@@ -42,11 +53,15 @@ async function getAnswer(question, opts = {}) {
     return result;
   }
   try {
-    const [best] = fuzzySearch(question, 1);
-    if (best && best.score <= 0.4) {
-      const method = best.score === 0 ? 'exact' : 'fuzzy';
-      const { questionText, answerTemplate } = selectLocalizedQA(best.item, lang, DEFAULT_LANG);
-      const check = validateVars(best.item, vars || {});
+    const fuzzyTop = fuzzySearch(question, TOPK);
+    const bestExact = fuzzyTop[0];
+    if (bestExact && bestExact.score === 0) {
+      const { questionText, answerTemplate } = selectLocalizedQA(
+        bestExact.item,
+        lang,
+        DEFAULT_LANG
+      );
+      const check = validateVars(bestExact.item, vars || {});
       if (!check.ok) {
         const list = check.missing.join(', ');
         const msg = `Чтобы я дал точный ответ, уточните, пожалуйста: ${list} 🙌`;
@@ -54,11 +69,11 @@ async function getAnswer(question, opts = {}) {
           responseId,
           answer: msg,
           source: 'local',
-          method,
+          method: 'exact',
           lang,
           matchedQuestion: questionText,
-          score: best.score,
-          itemId: best.item.id,
+          score: bestExact.score,
+          itemId: bestExact.item.id,
           needVars: check.missing
         };
       } else {
@@ -68,37 +83,137 @@ async function getAnswer(question, opts = {}) {
           responseId,
           answer: rendered,
           source: 'local',
-          method,
+          method: 'exact',
           lang,
           matchedQuestion: questionText,
-          score: best.score,
-          itemId: best.item.id,
+          score: bestExact.score,
+          itemId: bestExact.item.id,
           variablesUsed: Object.keys(safeVars)
         };
       }
-    } else {
-      const answer = await fallbackQuery(question, lang);
-      let pendingId;
-      if (process.env.AUTO_CACHE_OPENAI !== '0') {
-        try {
-          const requestHash = crypto
-            .createHash('sha1')
-            .update(`${question}\n${answer}`)
-            .digest('hex');
-          const pending = await store.addPending({
-            Question: question,
-            Answer: answer,
-            source: 'openai',
-            meta: { model: OPENAI_MODEL, requestHash }
-          });
-          pendingId = pending.id;
-          logger.info({ id: pendingId }, 'Cached OpenAI answer as pending');
-        } catch (err) {
-          logger.error({ err }, 'Failed to cache OpenAI answer');
-        }
-      }
-      result = { responseId, answer, source: 'openai', method: 'openai', pendingId, lang };
+      return result;
     }
+
+    if (SEM_ENABLED) {
+      const semTop = await searchSemantic(question, TOPK);
+      const ranked = hybridRank({ query: question, fuzzyResults: fuzzyTop, semResults: semTop });
+      const candidate = ranked[0];
+      if (candidate) {
+        const accept = candidate.sem_sim >= MIN_SIM || candidate.fuzzy_score <= 0.2;
+        metrics.recordSemantic({ accepted: accept });
+        if (accept && candidate.item) {
+          const method = candidate.sem_sim >= MIN_SIM ? 'semantic' : 'fuzzy';
+          const { questionText, answerTemplate } = selectLocalizedQA(
+            candidate.item,
+            lang,
+            DEFAULT_LANG
+          );
+          const check = validateVars(candidate.item, vars || {});
+          if (!check.ok) {
+            const list = check.missing.join(', ');
+            const msg = `Чтобы я дал точный ответ, уточните, пожалуйста: ${list} 🙌`;
+            result = {
+              responseId,
+              answer: msg,
+              source: 'local',
+              method,
+              rankMethod: 'hybrid',
+              lang,
+              matchedQuestion: questionText,
+              score: candidate.fuzzy_score,
+              semSim: candidate.sem_sim,
+              combinedScore: candidate.combined,
+              itemId: candidate.item.id,
+              needVars: check.missing
+            };
+          } else {
+            const safeVars = sanitizeVars(vars || {});
+            const rendered = renderAnswer(answerTemplate, safeVars);
+            result = {
+              responseId,
+              answer: rendered,
+              source: 'local',
+              method,
+              rankMethod: 'hybrid',
+              lang,
+              matchedQuestion: questionText,
+              score: candidate.fuzzy_score,
+              semSim: candidate.sem_sim,
+              combinedScore: candidate.combined,
+              itemId: candidate.item.id,
+              variablesUsed: Object.keys(safeVars)
+            };
+          }
+          return result;
+        }
+      } else {
+        metrics.recordSemantic({ accepted: false });
+      }
+    } else {
+      const best = fuzzyTop[0];
+      if (best && best.score <= 0.4) {
+        const method = 'fuzzy';
+        const { questionText, answerTemplate } = selectLocalizedQA(
+          best.item,
+          lang,
+          DEFAULT_LANG
+        );
+        const check = validateVars(best.item, vars || {});
+        if (!check.ok) {
+          const list = check.missing.join(', ');
+          const msg = `Чтобы я дал точный ответ, уточните, пожалуйста: ${list} 🙌`;
+          result = {
+            responseId,
+            answer: msg,
+            source: 'local',
+            method,
+            lang,
+            matchedQuestion: questionText,
+            score: best.score,
+            itemId: best.item.id,
+            needVars: check.missing
+          };
+        } else {
+          const safeVars = sanitizeVars(vars || {});
+          const rendered = renderAnswer(answerTemplate, safeVars);
+          result = {
+            responseId,
+            answer: rendered,
+            source: 'local',
+            method,
+            lang,
+            matchedQuestion: questionText,
+            score: best.score,
+            itemId: best.item.id,
+            variablesUsed: Object.keys(safeVars)
+          };
+        }
+        return result;
+      }
+    }
+
+    // Fallback to OpenAI
+    const answer = await fallbackQuery(question, lang);
+    let pendingId;
+    if (process.env.AUTO_CACHE_OPENAI !== '0') {
+      try {
+        const requestHash = crypto
+          .createHash('sha1')
+          .update(`${question}\n${answer}`)
+          .digest('hex');
+        const pending = await store.addPending({
+          Question: question,
+          Answer: answer,
+          source: 'openai',
+          meta: { model: OPENAI_MODEL, requestHash }
+        });
+        pendingId = pending.id;
+        logger.info({ id: pendingId }, 'Cached OpenAI answer as pending');
+      } catch (err) {
+        logger.error({ err }, 'Failed to cache OpenAI answer');
+      }
+    }
+    result = { responseId, answer, source: 'openai', method: 'openai', pendingId, lang };
     return result;
   } catch (error) {
     logger.error({ err: error }, 'Error in getAnswer');
@@ -111,10 +226,13 @@ async function getAnswer(question, opts = {}) {
       lang,
       source: result.source,
       method: result.method,
+      rankMethod: result.rankMethod,
       itemId: result.itemId,
       pendingId: result.pendingId,
       matchedQuestion: result.matchedQuestion,
       score: result.score,
+      semSim: result.semSim,
+      combinedScore: result.combinedScore,
       answer: result.answer
     });
   }

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -11,7 +11,10 @@ const counters = {
   feedbackTotal: 0,
   feedbackPositive: 0,
   feedbackNegative: 0,
-  feedbackNeutral: 0
+  feedbackNeutral: 0,
+  semanticQueriesTotal: 0,
+  semanticAccepted: 0,
+  semanticRejected: 0
 };
 
 const timings = {
@@ -53,6 +56,13 @@ function recordRequest(durationMs, source, lang) {
   langCounters[key] = (langCounters[key] || 0) + 1;
   requestEvents.push(Date.now());
   if (promHooks.incRequests) promHooks.incRequests({ source, lang: key });
+}
+
+function recordSemantic({ accepted }) {
+  counters.semanticQueriesTotal += 1;
+  if (accepted) counters.semanticAccepted += 1;
+  else counters.semanticRejected += 1;
+  if (promHooks.incSemantic) promHooks.incSemantic({ accepted });
 }
 
 function recordNoMatch(question) {
@@ -112,6 +122,9 @@ function snapshot() {
     feedbackPositive: counters.feedbackPositive,
     feedbackNegative: counters.feedbackNegative,
     feedbackNeutral: counters.feedbackNeutral,
+    semanticQueriesTotal: counters.semanticQueriesTotal,
+    semanticAccepted: counters.semanticAccepted,
+    semanticRejected: counters.semanticRejected,
     pendingTotal,
     avgDurationMs,
     maxDurationMs: timings.maxDurationMs,
@@ -143,6 +156,7 @@ module.exports = {
   recordFeedback,
   recordError,
   recordOpenAI,
+  recordSemantic,
   getMovingWindowStats,
   snapshot
 };


### PR DESCRIPTION
## Summary
- add embedders for local_xenova and OpenAI with caching
- build and persist HNSW semantic index with hybrid reranker
- extend support flow, metrics and admin API for semantic search

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68971de35ac08324abef9ea3047d5db9