### PR TITLE
feat: add tenant-aware indexing

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -188,7 +188,7 @@ startAlertScheduler(store, metrics);
 if (process.env.SEM_ENABLED === '1') {
   (async () => {
     try {
-      const info = await initSemantic();
+      const info = await initSemantic({ tenantId: orgStore.TENANT_DEFAULT_ID, projectId: 'root' });
       logger.info(
         {
           provider: info.provider,
@@ -207,7 +207,7 @@ if (process.env.RAG_ENABLED === '1') {
   (async () => {
     try {
       await initEmbedder();
-      const info = await initRagIndex({ embed });
+      const info = await initRagIndex({ embed, tenantId: orgStore.TENANT_DEFAULT_ID, projectId: 'root' });
       logger.info({ size: info.size, dim: info.dim }, 'RAG index initialized');
     } catch (err) {
       logger.error({ err }, 'Failed to initialize RAG index');

--- a/src/rag/index.js
+++ b/src/rag/index.js
@@ -3,27 +3,55 @@ const path = require('path');
 const { HierarchicalNSW } = require('hnswlib-node');
 const { logger } = require('../utils/logger');
 
-const DATA_DIR = process.env.RAG_INDEX_PATH || path.join(__dirname, '..', '..', 'data', 'rag');
-const INDEX_FILE = path.join(DATA_DIR, 'index.bin');
-const META_FILE = path.join(DATA_DIR, 'meta.json');
-const CHUNKS_FILE = path.join(DATA_DIR, 'chunks.jsonl');
+const DATA_BASE = process.env.RAG_INDEX_PATH || path.join(__dirname, '..', '..', 'data', 'tenants');
 
-let index = null;
-let dim = 0;
-let chunkMeta = new Map();
-let chunkIdToIdx = new Map();
-let idxToChunkId = [];
-let embedder = null;
-
-function ensureDir() {
-  fs.mkdirSync(DATA_DIR, { recursive: true });
+function makeKey(tenant = {}) {
+  const t = tenant.orgId || tenant.tenantId || 'default';
+  const p = tenant.projectId || 'root';
+  return `${t}:${p}`;
 }
 
-function readChunksFile() {
+function resolvePaths(tenant = {}) {
+  const tenantId = tenant.orgId || tenant.tenantId || 'default';
+  const projectId = tenant.projectId || 'root';
+  const root = tenant.basePath || DATA_BASE;
+  const tenantBase = path.join(root, tenantId, projectId);
+  const dir = path.join(tenantBase, 'rag');
+  return {
+    tenantBase,
+    dir,
+    indexFile: path.join(dir, 'index.bin'),
+    metaFile: path.join(dir, 'meta.json'),
+    chunksFile: path.join(dir, 'chunks.jsonl'),
+    sourcesFile: path.join(dir, 'sources.json')
+  };
+}
+
+const states = new Map();
+
+function getState(tenant = {}) {
+  const key = makeKey(tenant);
+  if (!states.has(key)) {
+    const paths = resolvePaths(tenant);
+    states.set(key, {
+      index: null,
+      dim: 0,
+      chunkMeta: new Map(),
+      chunkIdToIdx: new Map(),
+      idxToChunkId: [],
+      paths
+    });
+  }
+  const st = states.get(key);
+  if (!st.paths) st.paths = resolvePaths(tenant);
+  return st;
+}
+
+function readChunksFile(file) {
   const arr = [];
   try {
-    if (!fs.existsSync(CHUNKS_FILE)) return arr;
-    const lines = fs.readFileSync(CHUNKS_FILE, 'utf8').split('\n');
+    if (!fs.existsSync(file)) return arr;
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
     for (const line of lines) {
       if (!line.trim()) continue;
       try {
@@ -39,17 +67,26 @@ function readChunksFile() {
   return arr;
 }
 
-async function rebuildAll() {
-  ensureDir();
-  const all = readChunksFile();
-  chunkMeta = new Map();
-  chunkIdToIdx = new Map();
-  idxToChunkId = [];
+let embedder = null;
+
+async function embedderReady() {
+  if (!embedder) return;
+  if (embedder.initEmbedder) await embedder.initEmbedder();
+}
+
+async function rebuildAll(tenant = {}) {
+  const st = getState(tenant);
+  const { dir, chunksFile, indexFile, metaFile } = st.paths;
+  fs.mkdirSync(dir, { recursive: true });
+  const all = readChunksFile(chunksFile);
+  st.chunkMeta = new Map();
+  st.chunkIdToIdx = new Map();
+  st.idxToChunkId = [];
   if (all.length === 0) {
-    index = null;
-    dim = 0;
+    st.index = null;
+    st.dim = 0;
     fs.writeFileSync(
-      META_FILE,
+      metaFile,
       JSON.stringify({ dim: 0, size: 0, updatedAt: new Date().toISOString() }, null, 2)
     );
     return { size: 0, dim: 0 };
@@ -57,132 +94,144 @@ async function rebuildAll() {
   await embedderReady();
   const texts = all.map((c) => c.text);
   const vectors = await embedder.embed(texts);
-  dim = vectors[0].length;
-  index = new HierarchicalNSW('cosine', dim);
-  index.initIndex(vectors.length);
+  st.dim = vectors[0].length;
+  st.index = new HierarchicalNSW('cosine', st.dim);
+  st.index.initIndex(vectors.length);
   vectors.forEach((vec, i) => {
-    index.addPoint(vec, i);
+    st.index.addPoint(vec, i);
     const id = all[i].id;
-    idxToChunkId[i] = id;
-    chunkIdToIdx.set(id, i);
-    chunkMeta.set(id, all[i]);
+    st.idxToChunkId[i] = id;
+    st.chunkIdToIdx.set(id, i);
+    st.chunkMeta.set(id, all[i]);
   });
-  index.writeIndexSync(INDEX_FILE);
+  st.index.writeIndexSync(indexFile);
   fs.writeFileSync(
-    META_FILE,
-    JSON.stringify({ dim, size: vectors.length, updatedAt: new Date().toISOString(), ids: idxToChunkId }, null, 2)
+    metaFile,
+    JSON.stringify({ dim: st.dim, size: vectors.length, updatedAt: new Date().toISOString(), ids: st.idxToChunkId }, null, 2)
   );
-  logger.info({ size: vectors.length, dim }, 'RAG index rebuilt');
-  return { size: vectors.length, dim };
+  logger.info({ size: vectors.length, dim: st.dim }, 'RAG index rebuilt');
+  return { size: vectors.length, dim: st.dim };
 }
 
-async function embedderReady() {
-  if (!embedder) return;
-  if (embedder.initEmbedder) await embedder.initEmbedder();
-}
-
-async function initRagIndex(embed) {
+async function initRagIndex({ embed, ...tenant } = {}) {
   embedder = embed;
   await embedderReady();
-  ensureDir();
-  if (process.env.RAG_REBUILD_ON_START === '1' || !fs.existsSync(INDEX_FILE)) {
-    return rebuildAll();
+  const st = getState(tenant);
+  const { dir, indexFile, metaFile, chunksFile } = st.paths;
+  fs.mkdirSync(dir, { recursive: true });
+  if (process.env.RAG_REBUILD_ON_START === '1' || !fs.existsSync(indexFile)) {
+    return rebuildAll(tenant);
   }
   try {
-    const meta = JSON.parse(fs.readFileSync(META_FILE, 'utf8'));
-    dim = meta.dim;
-    index = new HierarchicalNSW('cosine', dim);
-    index.readIndexSync(INDEX_FILE, meta.size);
-    idxToChunkId = meta.ids || [];
-    chunkIdToIdx = new Map(idxToChunkId.map((id, i) => [id, i]));
-    const all = readChunksFile();
-    chunkMeta = new Map(all.map((c) => [c.id, c]));
-    logger.info({ size: meta.size, dim }, 'RAG index loaded');
-    return { size: meta.size, dim };
+    const meta = JSON.parse(fs.readFileSync(metaFile, 'utf8'));
+    st.dim = meta.dim;
+    st.index = new HierarchicalNSW('cosine', st.dim);
+    st.index.readIndexSync(indexFile, meta.size);
+    st.idxToChunkId = meta.ids || [];
+    st.chunkIdToIdx = new Map(st.idxToChunkId.map((id, i) => [id, i]));
+    const all = readChunksFile(chunksFile);
+    st.chunkMeta = new Map(all.map((c) => [c.id, c]));
+    logger.info({ size: meta.size, dim: st.dim }, 'RAG index loaded');
+    return { size: meta.size, dim: st.dim };
   } catch (err) {
     logger.error({ err }, 'Failed to load RAG index, rebuilding');
-    return rebuildAll();
+    return rebuildAll(tenant);
   }
 }
 
-async function upsertChunks(chunks = []) {
+async function upsertChunks(chunks = [], tenant = {}) {
   if (!chunks.length) return;
+  const st = getState(tenant);
+  const { indexFile, metaFile } = st.paths;
   await embedderReady();
   const texts = chunks.map((c) => c.text);
   const vectors = await embedder.embed(texts);
-  if (!index) {
-    dim = vectors[0].length;
-    index = new HierarchicalNSW('cosine', dim);
-    index.initIndex(vectors.length);
-    idxToChunkId = [];
-    chunkIdToIdx = new Map();
+  if (!st.index) {
+    st.dim = vectors[0].length;
+    st.index = new HierarchicalNSW('cosine', st.dim);
+    st.index.initIndex(vectors.length);
+    st.idxToChunkId = [];
+    st.chunkIdToIdx = new Map();
   }
   for (let i = 0; i < chunks.length; i++) {
     const c = chunks[i];
     const vec = vectors[i];
-    const idx = idxToChunkId.length;
-    index.addPoint(vec, idx);
-    idxToChunkId[idx] = c.id;
-    chunkIdToIdx.set(c.id, idx);
-    chunkMeta.set(c.id, c);
+    const idx = st.idxToChunkId.length;
+    st.index.addPoint(vec, idx);
+    st.idxToChunkId[idx] = c.id;
+    st.chunkIdToIdx.set(c.id, idx);
+    st.chunkMeta.set(c.id, c);
   }
-  index.writeIndexSync(INDEX_FILE);
+  st.index.writeIndexSync(indexFile);
   fs.writeFileSync(
-    META_FILE,
-    JSON.stringify({ dim, size: idxToChunkId.length, updatedAt: new Date().toISOString(), ids: idxToChunkId }, null, 2)
+    metaFile,
+    JSON.stringify({ dim: st.dim, size: st.idxToChunkId.length, updatedAt: new Date().toISOString(), ids: st.idxToChunkId }, null, 2)
   );
 }
 
-async function removeSource(sourceId) {
-  const all = readChunksFile().filter((c) => c.sourceId !== sourceId);
-  const tmp = CHUNKS_FILE + '.tmp';
+async function removeSource(sourceId, tenant = {}) {
+  const st = getState(tenant);
+  const { chunksFile, sourcesFile } = st.paths;
+  const all = readChunksFile(chunksFile).filter((c) => c.sourceId !== sourceId);
+  const tmp = chunksFile + '.tmp';
   fs.writeFileSync(tmp, all.map((c) => JSON.stringify(c)).join('\n') + (all.length ? '\n' : ''));
-  fs.renameSync(tmp, CHUNKS_FILE);
+  fs.renameSync(tmp, chunksFile);
   try {
-    const srcFile = path.join(DATA_DIR, 'sources.json');
     let sources = [];
-    if (fs.existsSync(srcFile)) {
-      sources = JSON.parse(fs.readFileSync(srcFile, 'utf8')).filter((s) => s.id !== sourceId);
-      const tmp2 = srcFile + '.tmp';
+    if (fs.existsSync(sourcesFile)) {
+      sources = JSON.parse(fs.readFileSync(sourcesFile, 'utf8')).filter((s) => s.id !== sourceId);
+      const tmp2 = sourcesFile + '.tmp';
       fs.writeFileSync(tmp2, JSON.stringify(sources, null, 2));
-      fs.renameSync(tmp2, srcFile);
+      fs.renameSync(tmp2, sourcesFile);
     }
   } catch (err) {
     logger.error({ err }, 'Failed to update sources on remove');
   }
-  return rebuildAll();
+  return rebuildAll(tenant);
 }
 
-async function searchChunks(query, k) {
-  if (!index || idxToChunkId.length === 0) return [];
+async function searchChunks(query, k, tenant = {}) {
+  const st = getState(tenant);
+  if (!st.index || st.idxToChunkId.length === 0) return [];
   await embedderReady();
   const [vec] = await embedder.embed([query]);
   if (!vec) return [];
   const topk = k || Number(process.env.RAG_TOPK || '6');
-  const result = index.searchKnn(vec, Math.min(topk, idxToChunkId.length));
+  const result = st.index.searchKnn(vec, Math.min(topk, st.idxToChunkId.length));
   const neighbors = result.neighbors || result[0] || [];
   const distances = result.distances || result[1] || [];
   const out = [];
   for (let i = 0; i < neighbors.length; i++) {
-    const chunkId = idxToChunkId[neighbors[i]];
-    const meta = chunkMeta.get(chunkId);
+    const chunkId = st.idxToChunkId[neighbors[i]];
+    const meta = st.chunkMeta.get(chunkId);
     if (!meta) continue;
     const sim = 1 - distances[i];
-    out.push({ chunkId, sourceId: meta.sourceId, sim, text: meta.text, title: meta.title, headings: meta.headings, start: meta.start, end: meta.end });
+    out.push({
+      chunkId,
+      sourceId: meta.sourceId,
+      sim,
+      text: meta.text,
+      title: meta.title,
+      headings: meta.headings,
+      start: meta.start,
+      end: meta.end
+    });
   }
   return out;
 }
 
-function status() {
+function status(tenant = {}) {
+  const st = getState(tenant);
+  const { metaFile } = st.paths;
   let updatedAt = null;
   try {
-    if (fs.existsSync(META_FILE)) {
-      updatedAt = JSON.parse(fs.readFileSync(META_FILE, 'utf8')).updatedAt;
+    if (fs.existsSync(metaFile)) {
+      updatedAt = JSON.parse(fs.readFileSync(metaFile, 'utf8')).updatedAt;
     }
   } catch (err) {
     logger.error({ err }, 'Failed to read RAG meta');
   }
-  return { size: idxToChunkId.length, dim, updatedAt };
+  return { size: st.idxToChunkId.length, dim: st.dim, updatedAt };
 }
 
 module.exports = { initRagIndex, upsertChunks, removeSource, searchChunks, status, rebuildAll };

--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -4,7 +4,8 @@ function retrieve(query, opts = {}) {
   const topK = opts.topK || Number(process.env.RAG_TOPK || '6');
   const diversify = opts.diversify === undefined ? process.env.RAG_DIVERSIFY_BY_SOURCE === '1' : opts.diversify;
   const maxChars = Number(process.env.RAG_MAX_CONTEXT_CHARS || '9000');
-  return searchChunks(query, topK).then((items) => {
+  const tenant = opts.tenant;
+  return searchChunks(query, topK, tenant).then((items) => {
     if (diversify) {
       const perSource = {};
       const limited = [];

--- a/src/support/support.js
+++ b/src/support/support.js
@@ -121,7 +121,7 @@ async function getAnswer(question, opts = {}) {
     }
 
     if (SEM_ENABLED) {
-      const semTop = await searchSemantic(question, TOPK);
+      const semTop = await searchSemantic(question, TOPK, tenant);
       const ranked = hybridRank({ query: question, fuzzyResults: fuzzyTop, semResults: semTop });
       const candidate = ranked[0];
       if (candidate) {
@@ -223,7 +223,7 @@ async function getAnswer(question, opts = {}) {
     let retrieval = null;
     if (RAG_ENABLED) {
       try {
-        retrieval = await retrieve(question);
+        retrieval = await retrieve(question, { tenant });
         const topSim = retrieval.items[0]?.sim || 0;
         if (retrieval.contextText && topSim >= RAG_MIN_SIM) {
           const ragAns = await answerWithRag({


### PR DESCRIPTION
## Summary
- resolve semantic and RAG index paths by tenant and project
- pass tenant context into semantic and RAG operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897344c03a08324a5451a68a8a3fc12