### PR TITLE
Remove temp file after RAG upload

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -573,6 +573,12 @@ router.post('/rag/upload', authMiddleware(['admin', 'editor']), upload.single('f
     req.log.error({ err }, 'RAG upload failed');
     auditLog(req, { action: 'rag.upload', ok: false, details: { error: err.message } });
     res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    fs.unlink(req.file.path, (err) => {
+      if (err) {
+        req.log.error({ err }, 'Failed to remove uploaded file');
+      }
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure RAG upload route always deletes the uploaded temp file after processing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68973a181f0483249a6c8ecbe2269294