### PR TITLE
feat(gateway): add RAG answer generation

### DIFF
--- a/packages/support-gateway/src/services/ragService.ts
+++ b/packages/support-gateway/src/services/ragService.ts
@@ -1,9 +1,28 @@
 import logger from '../utils/logger';
 
+// Import repository RAG utilities (commonjs modules)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { retrieve } = require('../../../../src/rag/retriever');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { answerWithRag } = require('../../../../src/rag/answerer');
+
 export async function generateResponse(message: string): Promise<string> {
   try {
-    // TODO: implement RAG logic
-    return `Echo: ${message}`;
+    // Retrieve relevant context for the incoming message
+    const { contextText, citations } = await retrieve(message);
+    if (!contextText) {
+      logger.warn({ message }, 'No context found for RAG query');
+    }
+
+    // Ask OpenAI for an answer using the retrieved context
+    const { answer } = await answerWithRag({
+      question: message,
+      contextText,
+      citations
+    });
+
+    logger.debug({ message, answer }, 'Generated RAG response');
+    return answer;
   } catch (err) {
     logger.error({ err }, 'RAG service error');
     throw err;


### PR DESCRIPTION
## Summary
- integrate repository RAG retriever and OpenAI answerer modules
- log retrieval context and generated answer
- replace echo logic with synthesized response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68973dab28688324b12daa23e9ff84e2