### PR TITLE
feat: add rag handler

### DIFF
--- a/packages/support-gateway/src/handlers/textHandler.ts
+++ b/packages/support-gateway/src/handlers/textHandler.ts
@@ -1,11 +1,23 @@
 import { Context } from 'telegraf';
 import logger from '../utils/logger';
+import supabase from '../db';
+import { generateResponse } from '../services/ragService';
 
 export default async function textHandler(ctx: Context) {
   try {
     const text = ctx.message && 'text' in ctx.message ? ctx.message.text : '';
     logger.info({ text }, 'Received text message');
-    await ctx.reply('Text received');
+
+    // store incoming user message
+    await supabase.from('messages').insert({ sender: 'user', content: text });
+
+    // generate answer via rag service
+    const answer = await generateResponse(text);
+
+    // store bot response
+    await supabase.from('messages').insert({ sender: 'bot', content: answer });
+
+    await ctx.reply(answer);
   } catch (err) {
     logger.error({ err }, 'Error in textHandler');
   }


### PR DESCRIPTION
## Summary
- save incoming messages to Supabase
- generate RAG answers and respond via bot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974029d2e48324922e3da92ef6274c