### PR TITLE
Queue media jobs for processing

### DIFF
--- a/packages/support-gateway/src/bot.ts
+++ b/packages/support-gateway/src/bot.ts
@@ -15,7 +15,7 @@ try {
   const { BOT_TOKEN } = envSchema.parse(process.env);
   bot = new Telegraf(BOT_TOKEN);
   bot.on('text', textHandler);
-  bot.on(['photo', 'video'], mediaHandler);
+  bot.on(['photo', 'video', 'voice', 'audio'], mediaHandler);
   logger.info('Bot initialized');
 } catch (err) {
   logger.error({ err }, 'Failed to initialize bot');

--- a/packages/support-gateway/src/handlers/mediaHandler.ts
+++ b/packages/support-gateway/src/handlers/mediaHandler.ts
@@ -1,10 +1,53 @@
 import { Context } from 'telegraf';
 import logger from '../utils/logger';
+import { audioQueue, videoQueue } from '../queue';
+import supabase from '../db';
 
 export default async function mediaHandler(ctx: Context) {
   try {
-    logger.info('Received media message');
-    await ctx.reply('Media received');
+    const message: any = ctx.message;
+    if (!message) return;
+
+    let fileId: string | undefined;
+    let mediaType: 'audio' | 'video' | 'photo' | undefined;
+
+    if (message.voice) {
+      fileId = message.voice.file_id;
+      mediaType = 'audio';
+    } else if (message.audio) {
+      fileId = message.audio.file_id;
+      mediaType = 'audio';
+    } else if (message.video) {
+      fileId = message.video.file_id;
+      mediaType = 'video';
+    } else if (message.photo) {
+      const photo = message.photo[message.photo.length - 1];
+      fileId = photo.file_id;
+      mediaType = 'photo';
+    }
+
+    if (!fileId || !mediaType) {
+      logger.warn('Unsupported media type');
+      return;
+    }
+
+    const link = await ctx.telegram.getFileLink(fileId);
+    const url = typeof link === 'string' ? link : link.href;
+
+    if (mediaType === 'audio') {
+      await audioQueue.add('transcription', { url });
+    } else {
+      let messageId: number | undefined;
+      const { data } = await supabase
+        .from('messages')
+        .insert({ video_url: url })
+        .select('id')
+        .single();
+      messageId = data?.id;
+      await videoQueue.add('vision', { url, messageId });
+    }
+
+    await ctx.reply('Media received, processing...');
   } catch (err) {
     logger.error({ err }, 'Error in mediaHandler');
   }

--- a/packages/support-gateway/src/queue.ts
+++ b/packages/support-gateway/src/queue.ts
@@ -1,0 +1,22 @@
+import { Queue } from 'bullmq';
+import IORedis from 'ioredis';
+import { z } from 'zod';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const envSchema = z.object({
+  REDIS_URL: z.string().url(),
+});
+
+const { REDIS_URL } = envSchema.parse(process.env);
+
+const connection = new IORedis(REDIS_URL);
+
+const defaultJobOptions = {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 5000 },
+};
+
+export const audioQueue = new Queue('audio', { connection, defaultJobOptions });
+export const videoQueue = new Queue('video', { connection, defaultJobOptions });


### PR DESCRIPTION
## Summary
- detect incoming audio/video media
- enqueue transcription or vision jobs for worker
- acknowledge Telegram user while media processed

## Testing
- `cd packages/support-gateway && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974392d61483249e59a867f003bb44