### PR TITLE
feat: secure telegram webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,11 @@ TG_WEBHOOK_PATH=/webhooks/telegram
 TG_WEBHOOK_PUBLIC_URL=
 TG_ALLOWED_USER_IDS=
 TG_ALERT_CHAT_ID=
+# Secret token for validating Telegram webhooks
+TG_WEBHOOK_SECRET=
+# Rate limiting for Telegram webhook
+TG_WEBHOOK_RATE_WINDOW_MS=60000
+TG_WEBHOOK_RATE_MAX=100
 
 # ----- Matrix (self-hosted)
 MATRIX_ENABLED=1


### PR DESCRIPTION
## Summary
- require secret token header on Telegram webhook and log unauthorized requests
- add rate limiting to Telegram webhook endpoint
- document Telegram webhook secret and rate limit env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689756d95f3c8324817bd4f63f253a54