### PR TITLE
feat: hash sensitive logs with SHA-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Chunk size, overlap, top-k and other parameters can be adjusted via `RAG_*` vari
 All questions, answers and ingested documents are scanned for PII, secrets and profanity
 according to `data/security/policies.yaml`. Matches can be redacted or blocked based on
 severity and environment toggles. Detections are logged to `logs/dlp.jsonl` (values hashed
-when `DLP_HASH_SENSITIVE_IN_LOGS=1`).
+with SHA-256 when `DLP_HASH_SENSITIVE_IN_LOGS=1`).
 
 Configure via `DLP_*` variables in `.env.example`: enable/observe mode, redaction style,
 allow lists and blocking behaviour. Policies can be hot-reloaded with the admin API.

--- a/src/security/dlp.js
+++ b/src/security/dlp.js
@@ -15,7 +15,7 @@ const stats = { in: { pii: 0, secrets: 0, profanity: 0, blocked: 0 }, out: { pii
 
 function hashIfNeeded(val) {
   if (process.env.DLP_HASH_SENSITIVE_IN_LOGS === '1') {
-    return crypto.createHash('sha1').update(String(val)).digest('hex');
+    return crypto.createHash('sha256').update(String(val)).digest('hex');
   }
   return val;
 }


### PR DESCRIPTION
## Summary
- use SHA-256 when hashing sensitive values in DLP logging
- document SHA-256 hashing in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689759e9fd2c8324a04aeb1f33dfbe09