### PR TITLE
feat(matrix): support https admin api base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,9 @@ MATRIX_ROOM_ID=!roomid:yourdomain.tld
 MATRIX_ALLOWED_MXIDS=@op1:yourdomain.tld,@op2:yourdomain.tld
 MATRIX_RATE_WINDOW_MS=60000
 MATRIX_RATE_MAX=60
+MATRIX_ADMIN_API_BASE=http://localhost:3000/admin
+# Set to 1 to allow self-signed certificates for MATRIX_ADMIN_API_BASE (development only)
+MATRIX_ADMIN_API_ALLOW_SELF_SIGNED=0
 
 # ----- Internal admin API token used by integrations
 OPERATOR_API_TOKEN=operator-internal-token


### PR DESCRIPTION
## Summary
- allow overriding Matrix admin API base URL via `MATRIX_ADMIN_API_BASE`
- optionally permit self-signed certs for Matrix admin API calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975d5bf0b48324babac61895bc9191