### PR TITLE
feat(operator-admin): add token-based auth guard and layout

### DIFF
--- a/packages/operator-admin/src/app/(auth)/login/page.tsx
+++ b/packages/operator-admin/src/app/(auth)/login/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [token, setToken] = useState('');
+
+  useEffect(() => {
+    if (localStorage.getItem('token')) {
+      router.replace('/conversations');
+    }
+  }, [router]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    localStorage.setItem('token', token);
+    router.push('/conversations');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="Token"
+          className="border p-2 rounded"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+          Войти
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/packages/operator-admin/src/app/ask-bot/page.tsx
+++ b/packages/operator-admin/src/app/ask-bot/page.tsx
@@ -1,10 +1,10 @@
 import AuthGuard from '../../components/AuthGuard';
 
-export default function ConversationsPage() {
+export default function AskBotPage() {
   return (
     <AuthGuard>
       <div className="p-4">
-        <h1 className="text-2xl font-bold mb-4">Диалоги</h1>
+        <h1 className="text-2xl font-bold mb-4">Спросить у бота</h1>
       </div>
     </AuthGuard>
   );

--- a/packages/operator-admin/src/app/layout.tsx
+++ b/packages/operator-admin/src/app/layout.tsx
@@ -1,19 +1,32 @@
-import './globals.css';
-import Link from 'next/link';
+"use client";
+
+import "./globals.css";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const router = useRouter();
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    router.push("/login");
+  };
+
   return (
     <html lang="ru">
       <body className="min-h-screen flex flex-col">
-        <nav className="bg-gray-100 p-4 flex gap-4">
-          <Link href="/">Главная</Link>
-          <Link href="/conversations">Диалоги</Link>
-          <Link href="/login">Вход</Link>
-        </nav>
+        <header className="bg-gray-100 p-4 flex items-center justify-between">
+          <h1 className="font-bold">Операторская панель</h1>
+          <nav className="flex gap-4 items-center">
+            <Link href="/conversations">Диалоги</Link>
+            <Link href="/ask-bot">Спросить у бота</Link>
+            <button onClick={handleLogout}>Выход</button>
+          </nav>
+        </header>
         <main className="flex-1 p-4">{children}</main>
       </body>
     </html>

--- a/packages/operator-admin/src/app/login/page.tsx
+++ b/packages/operator-admin/src/app/login/page.tsx
@@ -1,9 +1,0 @@
-import LoginForm from '../components/LoginForm';
-
-export default function LoginPage() {
-  return (
-    <div className="flex items-center justify-center h-full">
-      <LoginForm />
-    </div>
-  );
-}

--- a/packages/operator-admin/src/app/page.tsx
+++ b/packages/operator-admin/src/app/page.tsx
@@ -1,10 +1,5 @@
-import ChatList from './components/ChatList';
+import { redirect } from 'next/navigation';
 
 export default function HomePage() {
-  return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold mb-4">💬 Чаты поддержки</h1>
-      <ChatList />
-    </main>
-  );
+  redirect('/conversations');
 }

--- a/packages/operator-admin/src/components/AuthGuard.tsx
+++ b/packages/operator-admin/src/components/AuthGuard.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ReactNode, useEffect, useState } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function AuthGuard({ children }: Props) {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.replace('/login');
+    } else {
+      setAuthorized(true);
+    }
+  }, [router]);
+
+  if (!authorized) return null;
+  return <>{children}</>;
+}

--- a/packages/operator-admin/src/lib/api.ts
+++ b/packages/operator-admin/src/lib/api.ts
@@ -1,0 +1,16 @@
+'use client';
+
+export function api(path: string, init: RequestInit = {}) {
+  const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+
+  const headers: HeadersInit = {
+    ...init.headers,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
+  return fetch(`${base}${path}`, {
+    ...init,
+    headers,
+  });
+}


### PR DESCRIPTION
## Summary
- add API helper that attaches token-based Authorization header
- add token login page and AuthGuard for protected routes
- create base layout with navigation and logout
- scaffold conversations and ask-bot pages

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68977a9e77f483248d9acd07d2abde3d