### PR TITLE
feat(operator-admin): add chat view with SSE

### DIFF
--- a/packages/operator-admin/src/app/conversations/[id]/page.tsx
+++ b/packages/operator-admin/src/app/conversations/[id]/page.tsx
@@ -1,21 +1,19 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
 import AuthGuard from '../../../components/AuthGuard';
-import { Button } from '@shadcn/ui/button';
+import ChatView from '../../../components/ChatView';
+import MessageInput from '../../../components/MessageInput';
 
-export default function ConversationPage() {
-  const params = useParams();
-  const router = useRouter();
-  const id = Array.isArray(params?.id) ? params.id[0] : (params?.id as string);
-
+export default function ConversationPage({ params }: { params: { id: string } }) {
+  const { id } = params;
   return (
     <AuthGuard>
-      <div className="p-4">
-        <h1 className="text-2xl font-bold mb-4">Диалог {id}</h1>
-        <Button onClick={() => router.back()}>Назад</Button>
+      <div className="flex flex-col h-screen p-4">
+        <div className="flex-1 overflow-y-auto mb-4">
+          <ChatView conversationId={id} />
+        </div>
+        <MessageInput conversationId={id} />
       </div>
     </AuthGuard>
   );
 }
-

--- a/packages/operator-admin/src/components/ChatView.tsx
+++ b/packages/operator-admin/src/components/ChatView.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@shadcn/ui/button';
+import { api } from '../lib/api';
+import { connectSSE } from '../lib/stream';
+
+interface Message {
+  id: string;
+  role: 'user' | 'bot' | 'operator';
+  content: string;
+  created_at: string;
+  media_urls?: string[];
+  transcript?: string;
+  vision_summary?: string;
+  conversation_id?: string;
+}
+
+interface ChatViewProps {
+  conversationId: string;
+}
+
+export default function ChatView({ conversationId }: ChatViewProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [handoff, setHandoff] = useState(false);
+  const messagesRef = useRef<Message[]>([]);
+
+  messagesRef.current = messages;
+
+  const loadMessages = async (initial = false) => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ limit: '50' });
+      if (!initial && cursor) params.append('cursor', cursor);
+      const res = await api(`/admin/conversations/${conversationId}/messages?${params.toString()}`);
+      if (!res.ok) throw new Error('Network error');
+      const data = await res.json();
+      const list: Message[] = Array.isArray(data) ? data : data.data || [];
+      const sorted = list.reverse();
+      setMessages((prev) => (initial ? sorted : [...sorted, ...prev]));
+      if (list.length < 50) setHasMore(false);
+      if (list.length > 0) {
+        const oldest = list[list.length - 1];
+        setCursor(oldest.created_at);
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setMessages([]);
+    setCursor(null);
+    setHasMore(true);
+    setHandoff(false);
+    loadMessages(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationId]);
+
+  useEffect(() => {
+    const handleLocal = (e: Event) => {
+      const detail = (e as CustomEvent<Message>).detail;
+      if (detail && detail.conversation_id === conversationId) {
+        setMessages((prev) => [...prev, detail]);
+      }
+    };
+    window.addEventListener('op_reply', handleLocal as EventListener);
+    return () => {
+      window.removeEventListener('op_reply', handleLocal as EventListener);
+    };
+  }, [conversationId]);
+
+  useEffect(() => {
+    const es = connectSSE();
+    es.addEventListener('user_msg', (e) => {
+      const data = JSON.parse((e as MessageEvent).data);
+      if (data.conversation_id === conversationId) {
+        loadMessages(true);
+      }
+    });
+    es.addEventListener('media_upd', (e) => {
+      const data = JSON.parse((e as MessageEvent).data);
+      if (messagesRef.current.some((m) => m.id === data.message_id)) {
+        loadMessages(true);
+      }
+    });
+    es.addEventListener('handoff', (e) => {
+      const data = JSON.parse((e as MessageEvent).data);
+      if (data.conversation_id === conversationId) {
+        setHandoff(true);
+      }
+    });
+    return () => {
+      es.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationId]);
+
+  const handleLoadMore = () => {
+    if (!loading) {
+      loadMessages();
+    }
+  };
+
+  const roleBg = (role: Message['role']) => {
+    if (role === 'operator') return 'bg-blue-100';
+    if (role === 'bot') return 'bg-green-100';
+    return 'bg-gray-100';
+  };
+
+  return (
+    <div>
+      {handoff && (
+        <div className="p-2 bg-yellow-100 text-center mb-2">Разговор передан оператору</div>
+      )}
+      {hasMore && (
+        <div className="text-center my-2">
+          <Button onClick={handleLoadMore} disabled={loading}>
+            Загрузить ещё
+          </Button>
+        </div>
+      )}
+      <div className="space-y-2">
+        {messages.map((m) => (
+          <div key={m.id} className={`p-2 rounded ${roleBg(m.role)}`}>
+            <div className="text-xs text-gray-600 mb-1">
+              {new Date(m.created_at).toLocaleString()} — {m.role}
+            </div>
+            <div>{m.content}</div>
+            {m.media_urls && m.media_urls.length > 0 && (
+              <div className="mt-2 space-y-2">
+                {m.media_urls.map((url) => (
+                  <div key={url}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-600 underline"
+                    >
+                      {url}
+                    </a>
+                    <img src={url} alt="media" className="mt-1 max-w-xs" />
+                  </div>
+                ))}
+              </div>
+            )}
+            {(m.transcript || m.vision_summary) && (
+              <div className="mt-1 text-sm text-gray-600">
+                {m.transcript && <div>📜 {m.transcript}</div>}
+                {m.vision_summary && <div>👁️ {m.vision_summary}</div>}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/operator-admin/src/components/MessageInput.tsx
+++ b/packages/operator-admin/src/components/MessageInput.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@shadcn/ui/button';
+import { Input } from '@shadcn/ui/input';
+import { api } from '../lib/api';
+
+interface MessageInputProps {
+  conversationId: string;
+}
+
+export default function MessageInput({ conversationId }: MessageInputProps) {
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const handleSend = async () => {
+    if (!text.trim() || sending) return;
+    setSending(true);
+    try {
+      const res = await api(`/admin/conversations/${conversationId}/reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      if (!res.ok) throw new Error('Network error');
+      const data = await res.json();
+      const message = data?.data || data;
+      window.dispatchEvent(new CustomEvent('op_reply', { detail: message }));
+      setText('');
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="flex space-x-2">
+      <Input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKey}
+        placeholder="Введите сообщение"
+        className="flex-1"
+      />
+      <Button onClick={handleSend} disabled={sending}>
+        Отправить
+      </Button>
+    </div>
+  );
+}

--- a/packages/operator-admin/src/lib/stream.ts
+++ b/packages/operator-admin/src/lib/stream.ts
@@ -1,0 +1,10 @@
+'use client';
+
+export function connectSSE() {
+  const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const url = token
+    ? `${base}/admin/stream?token=${encodeURIComponent(token)}`
+    : `${base}/admin/stream`;
+  return new EventSource(url);
+}


### PR DESCRIPTION
## Summary
- add ChatView component that paginates messages, handles SSE updates and handoff banner
- add MessageInput for sending operator replies and dispatching local updates
- wire up SSE connector and conversation page

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689783d7f53c8324a856e5746b2d1148