### PR TITLE
feat: add handoff controls

### DIFF
--- a/packages/operator-admin/src/app/conversations/[id]/page.tsx
+++ b/packages/operator-admin/src/app/conversations/[id]/page.tsx
@@ -1,16 +1,71 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import { Button } from '@shadcn/ui/button';
 import AuthGuard from '../../../components/AuthGuard';
 import ChatView from '../../../components/ChatView';
 import MessageInput from '../../../components/MessageInput';
+import { api } from '../../../lib/api';
+
+interface Conversation {
+  id: string;
+  status: string;
+  handoff: 'human' | 'bot';
+}
 
 export default function ConversationPage({ params }: { params: { id: string } }) {
   const { id } = params;
+  const [conversation, setConversation] = useState<Conversation | null>(null);
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await api(`/admin/conversations/${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setConversation(data);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleReturn = async () => {
+    const res = await api(`/admin/conversations/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handoff: 'bot' }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setConversation(data);
+      setToast('Теперь беседа снова обрабатывается ботом');
+      setTimeout(() => setToast(''), 3000);
+    }
+  };
+
   return (
     <AuthGuard>
       <div className="flex flex-col h-screen p-4">
+        {toast && (
+          <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded">
+            {toast}
+          </div>
+        )}
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold">Диалог {id}</h1>
+            {conversation && (
+              <div className="text-sm text-gray-600">
+                status: {conversation.status}, handoff: {conversation.handoff}
+              </div>
+            )}
+          </div>
+          {conversation?.handoff === 'human' && (
+            <Button onClick={handleReturn}>Вернуть боту</Button>
+          )}
+        </div>
         <div className="flex-1 overflow-y-auto mb-4">
-          <ChatView conversationId={id} />
+          <ChatView conversationId={id} initialHandoff={conversation?.handoff === 'human'} />
         </div>
         <MessageInput conversationId={id} />
       </div>

--- a/packages/operator-admin/src/app/conversations/page.tsx
+++ b/packages/operator-admin/src/app/conversations/page.tsx
@@ -13,8 +13,8 @@ interface Filters {
 
 export default function ConversationsPage() {
   const [filters, setFilters] = useState<Filters>({
-    status: 'all',
-    handoff: 'all',
+    status: 'open',
+    handoff: 'human',
     search: '',
   });
 

--- a/packages/operator-admin/src/components/ChatView.tsx
+++ b/packages/operator-admin/src/components/ChatView.tsx
@@ -18,14 +18,15 @@ interface Message {
 
 interface ChatViewProps {
   conversationId: string;
+  initialHandoff?: boolean;
 }
 
-export default function ChatView({ conversationId }: ChatViewProps) {
+export default function ChatView({ conversationId, initialHandoff = false }: ChatViewProps) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [cursor, setCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(false);
-  const [handoff, setHandoff] = useState(false);
+  const [handoff, setHandoff] = useState(initialHandoff);
   const messagesRef = useRef<Message[]>([]);
 
   messagesRef.current = messages;
@@ -58,10 +59,14 @@ export default function ChatView({ conversationId }: ChatViewProps) {
     setMessages([]);
     setCursor(null);
     setHasMore(true);
-    setHandoff(false);
+    setHandoff(initialHandoff);
     loadMessages(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
+
+  useEffect(() => {
+    setHandoff(initialHandoff);
+  }, [initialHandoff]);
 
   useEffect(() => {
     const handleLocal = (e: Event) => {
@@ -93,7 +98,7 @@ export default function ChatView({ conversationId }: ChatViewProps) {
     es.addEventListener('handoff', (e) => {
       const data = JSON.parse((e as MessageEvent).data);
       if (data.conversation_id === conversationId) {
-        setHandoff(true);
+        setHandoff(data.handoff === 'human');
       }
     });
     return () => {

--- a/packages/support-gateway/src/handlers/textHandler.ts
+++ b/packages/support-gateway/src/handlers/textHandler.ts
@@ -75,11 +75,10 @@ export default async function textHandler(ctx: Context) {
       });
       await ctx.reply(notice);
 
-      liveBus?.emit?.('handoff', {
-        conversation_id,
-        userTelegramId: String(userId),
-        text,
-      });
+        liveBus?.emit?.('handoff', {
+          conversation_id,
+          handoff: 'human',
+        });
       return;
     }
 

--- a/packages/support-gateway/src/routes/admin.stream.ts
+++ b/packages/support-gateway/src/routes/admin.stream.ts
@@ -18,7 +18,7 @@ export default async function adminStreamRoutes(server: FastifyInstance) {
 
       const ping = setInterval(() => send('ping', {}), 15000);
 
-      const handoff = (p: { conversation_id: number; text: string }) =>
+      const handoff = (p: { conversation_id: number; handoff: 'human' | 'bot' }) =>
         send('handoff', p);
       const newUser = (p: { conversation_id: number; message_id: number }) =>
         send('user_msg', p);


### PR DESCRIPTION
## Summary
- default conversation list to open human handoffs
- allow returning conversation to bot with status shown
- broadcast handoff changes via SSE

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689787b9299483249b66c5073f2afabb