### PR TITLE
feat: add operator notes

### DIFF
--- a/infrastructure/002_create_operator_notes.sql
+++ b/infrastructure/002_create_operator_notes.sql
@@ -1,0 +1,12 @@
+-- 002_create_operator_notes.sql
+
+CREATE TABLE IF NOT EXISTS operator_notes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+  author_name TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS operator_notes_conversation_created_at_idx ON operator_notes (conversation_id, created_at);

--- a/packages/operator-admin/src/app/conversations/[id]/page.tsx
+++ b/packages/operator-admin/src/app/conversations/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '@shadcn/ui/button';
 import AuthGuard from '../../../components/AuthGuard';
 import ChatView from '../../../components/ChatView';
 import MessageInput from '../../../components/MessageInput';
+import NotesPanel from '../../../components/NotesPanel';
 import { api } from '../../../lib/api';
 
 interface Conversation {
@@ -64,10 +65,17 @@ export default function ConversationPage({ params }: { params: { id: string } })
             <Button onClick={handleReturn}>Вернуть боту</Button>
           )}
         </div>
-        <div className="flex-1 overflow-y-auto mb-4">
-          <ChatView conversationId={id} initialHandoff={conversation?.handoff === 'human'} />
+        <div className="flex-1 flex flex-col md:flex-row gap-4 mb-4 overflow-hidden">
+          <div className="flex-1 flex flex-col">
+            <div className="flex-1 overflow-y-auto mb-4">
+              <ChatView conversationId={id} initialHandoff={conversation?.handoff === 'human'} />
+            </div>
+            <MessageInput conversationId={id} />
+          </div>
+          <div className="md:w-80 w-full flex-shrink-0 overflow-y-auto">
+            <NotesPanel conversationId={id} />
+          </div>
         </div>
-        <MessageInput conversationId={id} />
       </div>
     </AuthGuard>
   );

--- a/packages/operator-admin/src/components/NotesPanel.tsx
+++ b/packages/operator-admin/src/components/NotesPanel.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@shadcn/ui/button';
+import { Trash2 } from 'lucide-react';
+import { api } from '../lib/api';
+
+interface Note {
+  id: string;
+  conversation_id: string;
+  message_id?: string | null;
+  author_name: string;
+  content: string;
+  created_at: string;
+}
+
+export default function NotesPanel({ conversationId }: { conversationId: string }) {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [content, setContent] = useState('');
+  const operatorName = typeof window !== 'undefined' ? localStorage.getItem('operatorName') : null;
+
+  const loadNotes = async () => {
+    const res = await api(`/admin/conversations/${conversationId}/notes`);
+    if (res.ok) {
+      const data = await res.json();
+      setNotes(data.notes || []);
+    }
+  };
+
+  useEffect(() => {
+    loadNotes();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationId]);
+
+  const handleSave = async () => {
+    if (!operatorName || !content.trim()) return;
+    const res = await api(`/admin/conversations/${conversationId}/notes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, author_name: operatorName })
+    });
+    if (res.ok) {
+      const note = await res.json();
+      setNotes((prev) => [...prev, note]);
+      setContent('');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    const res = await api(`/admin/notes/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      setNotes((prev) => prev.filter((n) => n.id !== id));
+    }
+  };
+
+  if (!operatorName) {
+    return (
+      <div className="p-2 text-sm text-gray-600">
+        Укажите имя оператора в{' '}
+        <a href="/settings" className="underline text-blue-600">
+          настройках
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full border rounded p-2">
+      <div className="flex-1 overflow-y-auto space-y-2 mb-2">
+        {notes.map((n) => (
+          <div key={n.id} className="relative p-2 border rounded">
+            <button
+              className="absolute top-1 right-1 text-gray-500 hover:text-red-600"
+              onClick={() => handleDelete(n.id)}
+              aria-label="Удалить"
+            >
+              <Trash2 size={16} />
+            </button>
+            <div className="text-xs text-gray-600 mb-1">
+              {n.author_name} — {new Date(n.created_at).toLocaleString()}
+            </div>
+            <div className="whitespace-pre-wrap text-sm">{n.content}</div>
+          </div>
+        ))}
+      </div>
+      <div>
+        <textarea
+          className="w-full border rounded p-2 mb-2"
+          rows={3}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <Button onClick={handleSave} disabled={!content.trim()}>
+          Сохранить
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/support-gateway/src/routes/admin.notes.ts
+++ b/packages/support-gateway/src/routes/admin.notes.ts
@@ -1,0 +1,67 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import supabase from '../db';
+
+export default async function adminNotesRoutes(server: FastifyInstance) {
+  server.addHook('preHandler', server.verifyOperatorAuth);
+
+  server.get('/conversations/:id/notes', async (request, reply) => {
+    const paramsSchema = z.object({ id: z.string() });
+    const { id } = paramsSchema.parse(request.params);
+
+    const { data, error } = await supabase
+      .from('operator_notes')
+      .select('id, conversation_id, message_id, author_name, content, created_at')
+      .eq('conversation_id', id)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      reply.code(500).send({ error: error.message });
+      return;
+    }
+
+    reply.send({ notes: data || [] });
+  });
+
+  server.post('/conversations/:id/notes', async (request, reply) => {
+    const paramsSchema = z.object({ id: z.string() });
+    const bodySchema = z.object({
+      content: z.string(),
+      message_id: z.string().optional(),
+      author_name: z.string(),
+    });
+
+    const { id } = paramsSchema.parse(request.params);
+    const { content, message_id, author_name } = bodySchema.parse(request.body);
+
+    const { data, error } = await supabase
+      .from('operator_notes')
+      .insert({ conversation_id: id, content, message_id, author_name })
+      .select('id, conversation_id, message_id, author_name, content, created_at')
+      .single();
+
+    if (error || !data) {
+      reply.code(500).send({ error: error?.message });
+      return;
+    }
+
+    reply.send(data);
+  });
+
+  server.delete('/notes/:noteId', async (request, reply) => {
+    const paramsSchema = z.object({ noteId: z.string() });
+    const { noteId } = paramsSchema.parse(request.params);
+
+    const { error } = await supabase
+      .from('operator_notes')
+      .delete()
+      .eq('id', noteId);
+
+    if (error) {
+      reply.code(500).send({ error: error.message });
+      return;
+    }
+
+    reply.send({ ok: true });
+  });
+}

--- a/packages/support-gateway/src/server.ts
+++ b/packages/support-gateway/src/server.ts
@@ -6,6 +6,7 @@ import bot from './bot';
 import { generateResponse } from './services/ragService';
 import adminRoutes from './routes/admin.conversations';
 import adminStreamRoutes from './routes/admin.stream';
+import adminNotesRoutes from './routes/admin.notes';
 import verifyOperatorAuth from './config/auth';
 
 config();
@@ -19,6 +20,7 @@ async function buildServer() {
 
   await server.register(verifyOperatorAuth);
   await server.register(adminRoutes, { prefix: '/admin' });
+  await server.register(adminNotesRoutes, { prefix: '/admin' });
   await server.register(adminStreamRoutes);
 
   server.get('/healthz', async () => ({ ok: true }));


### PR DESCRIPTION
## Summary
- add Supabase migration and API routes for operator notes
- show conversation notes in admin with create/delete

## Testing
- `cd packages/support-gateway && npm test`
- `cd packages/operator-admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978dcda92c83249bc4ca9d7663f425