### PR TITLE
feat: add saved replies

### DIFF
--- a/infrastructure/003_create_saved_replies.sql
+++ b/infrastructure/003_create_saved_replies.sql
@@ -1,0 +1,13 @@
+-- 003_create_saved_replies.sql
+
+CREATE TABLE IF NOT EXISTS saved_replies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  tags TEXT[] DEFAULT '{}',
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  created_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS saved_replies_title_idx ON saved_replies (title);
+CREATE INDEX IF NOT EXISTS saved_replies_tags_idx ON saved_replies USING GIN (tags);

--- a/packages/operator-admin/src/components/MessageInput.tsx
+++ b/packages/operator-admin/src/components/MessageInput.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from '@shadcn/ui/button';
 import { Input } from '@shadcn/ui/input';
 import { api } from '../lib/api';
+import SavedRepliesDrawer from './SavedRepliesDrawer';
 
 interface MessageInputProps {
   conversationId: string;
@@ -43,6 +44,7 @@ export default function MessageInput({ conversationId }: MessageInputProps) {
 
   return (
     <div className="flex space-x-2">
+      <SavedRepliesDrawer onInsert={(t) => setText((prev) => prev + t)} />
       <Input
         value={text}
         onChange={(e) => setText(e.target.value)}

--- a/packages/operator-admin/src/components/SavedRepliesDrawer.tsx
+++ b/packages/operator-admin/src/components/SavedRepliesDrawer.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@shadcn/ui/button';
+import { Input } from '@shadcn/ui/input';
+import { api } from '../lib/api';
+
+interface SavedReply {
+  id: string;
+  title: string;
+  content: string;
+  tags: string[];
+  updated_at: string;
+}
+
+interface SavedRepliesDrawerProps {
+  onInsert: (text: string) => void;
+}
+
+export default function SavedRepliesDrawer({ onInsert }: SavedRepliesDrawerProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [tag, setTag] = useState('');
+  const [replies, setReplies] = useState<SavedReply[]>([]);
+  const [editing, setEditing] = useState<SavedReply | null>(null);
+  const [form, setForm] = useState({ title: '', content: '', tags: '' });
+
+  const load = async () => {
+    const params = new URLSearchParams();
+    if (search) params.append('search', search);
+    if (tag) params.append('tag', tag);
+    const res = await api(`/admin/saved-replies?${params.toString()}`);
+    if (res.ok) {
+      const data = await res.json();
+      setReplies(data.replies || data || []);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      load();
+    }
+  }, [open, search, tag]);
+
+  const allTags = Array.from(new Set(replies.flatMap((r) => r.tags)));
+
+  const openNew = () => {
+    setForm({ title: '', content: '', tags: '' });
+    setEditing({ id: '', title: '', content: '', tags: [], updated_at: '' });
+  };
+
+  const openEdit = (r: SavedReply) => {
+    setForm({ title: r.title, content: r.content, tags: r.tags.join(', ') });
+    setEditing(r);
+  };
+
+  const save = async () => {
+    const payload = {
+      title: form.title,
+      content: form.content,
+      tags: form.tags
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean),
+    };
+    let res;
+    if (editing && editing.id) {
+      res = await api(`/admin/saved-replies/${editing.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    } else {
+      res = await api('/admin/saved-replies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+    if (res.ok) {
+      setEditing(null);
+      load();
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!confirm('Удалить шаблон?')) return;
+    const res = await api(`/admin/saved-replies/${id}`, { method: 'DELETE' });
+    if (res.ok) load();
+  };
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} variant="secondary">
+        Сохранённые
+      </Button>
+      {open && (
+        <div className="fixed inset-0 flex justify-end z-50">
+          <div
+            className="absolute inset-0 bg-black opacity-50"
+            onClick={() => setOpen(false)}
+          ></div>
+          <div className="relative w-80 h-full bg-white shadow-xl p-4 overflow-y-auto">
+            <div className="mb-2 flex items-center space-x-2">
+              <Input
+                placeholder="Поиск"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              <select
+                className="border rounded p-1"
+                value={tag}
+                onChange={(e) => setTag(e.target.value)}
+              >
+                <option value="">Все теги</option>
+                {allTags.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              <Button onClick={openNew}>Добавить</Button>
+            </div>
+            <div className="space-y-2">
+              {replies.map((r) => (
+                <div key={r.id} className="border p-2 rounded">
+                  <div className="font-medium">{r.title}</div>
+                  {r.tags.length > 0 && (
+                    <div className="text-xs text-gray-500">{r.tags.join(', ')}</div>
+                  )}
+                  <div className="mt-1 text-sm whitespace-pre-wrap break-words">
+                    {r.content}
+                  </div>
+                  <div className="mt-2 flex space-x-2">
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        onInsert(r.content);
+                        setOpen(false);
+                      }}
+                    >
+                      Вставить
+                    </Button>
+                    <Button size="sm" variant="secondary" onClick={() => openEdit(r)}>
+                      Редактировать
+                    </Button>
+                    <Button size="sm" variant="destructive" onClick={() => remove(r.id)}>
+                      Удалить
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+      {editing && (
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <div
+            className="absolute inset-0 bg-black opacity-50"
+            onClick={() => setEditing(null)}
+          ></div>
+          <div className="relative bg-white p-4 w-96 space-y-2 rounded shadow">
+            <Input
+              placeholder="Заголовок"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+            />
+            <textarea
+              className="w-full border rounded p-2 h-40"
+              placeholder="Контент"
+              value={form.content}
+              onChange={(e) => setForm({ ...form, content: e.target.value })}
+            />
+            <Input
+              placeholder="Теги через запятую"
+              value={form.tags}
+              onChange={(e) => setForm({ ...form, tags: e.target.value })}
+            />
+            <div className="flex justify-end space-x-2">
+              <Button variant="secondary" onClick={() => setEditing(null)}>
+                Отмена
+              </Button>
+              <Button onClick={save}>Сохранить</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/support-gateway/src/routes/admin.saved-replies.ts
+++ b/packages/support-gateway/src/routes/admin.saved-replies.ts
@@ -1,0 +1,103 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import supabase from '../db';
+
+export default async function adminSavedRepliesRoutes(server: FastifyInstance) {
+  server.addHook('preHandler', server.verifyOperatorAuth);
+
+  server.get('/saved-replies', async (request, reply) => {
+    const querySchema = z.object({
+      search: z.string().optional(),
+      tag: z.string().optional(),
+    });
+    const { search, tag } = querySchema.parse(request.query);
+
+    let query = supabase
+      .from('saved_replies')
+      .select('id, title, content, tags, updated_at, created_by')
+      .order('updated_at', { ascending: false });
+
+    if (search) {
+      query = query.or(`title.ilike.%${search}%,content.ilike.%${search}%`);
+    }
+    if (tag) {
+      query = query.contains('tags', [tag]);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      reply.code(500).send({ error: error.message });
+      return;
+    }
+
+    reply.send({ replies: data || [] });
+  });
+
+  server.post('/saved-replies', async (request, reply) => {
+    const bodySchema = z.object({
+      title: z.string(),
+      content: z.string(),
+      tags: z.array(z.string()).optional().default([]),
+      created_by: z.string().optional(),
+    });
+    const { title, content, tags, created_by } = bodySchema.parse(request.body);
+
+    const { data, error } = await supabase
+      .from('saved_replies')
+      .insert({ title, content, tags, created_by })
+      .select('id, title, content, tags, updated_at, created_by')
+      .single();
+
+    if (error || !data) {
+      reply.code(500).send({ error: error?.message });
+      return;
+    }
+
+    reply.send(data);
+  });
+
+  server.patch('/saved-replies/:id', async (request, reply) => {
+    const paramsSchema = z.object({ id: z.string() });
+    const bodySchema = z.object({
+      title: z.string().optional(),
+      content: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+    });
+
+    const { id } = paramsSchema.parse(request.params);
+    const body = bodySchema.parse(request.body);
+    const updates = { ...body, updated_at: new Date().toISOString() };
+
+    const { data, error } = await supabase
+      .from('saved_replies')
+      .update(updates)
+      .eq('id', id)
+      .select('id, title, content, tags, updated_at, created_by')
+      .single();
+
+    if (error || !data) {
+      reply.code(500).send({ error: error?.message });
+      return;
+    }
+
+    reply.send(data);
+  });
+
+  server.delete('/saved-replies/:id', async (request, reply) => {
+    const paramsSchema = z.object({ id: z.string() });
+    const { id } = paramsSchema.parse(request.params);
+
+    const { error } = await supabase
+      .from('saved_replies')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      reply.code(500).send({ error: error.message });
+      return;
+    }
+
+    reply.send({ ok: true });
+  });
+}

--- a/packages/support-gateway/src/server.ts
+++ b/packages/support-gateway/src/server.ts
@@ -7,6 +7,7 @@ import { generateResponse } from './services/ragService';
 import adminRoutes from './routes/admin.conversations';
 import adminStreamRoutes from './routes/admin.stream';
 import adminNotesRoutes from './routes/admin.notes';
+import adminSavedRepliesRoutes from './routes/admin.saved-replies';
 import verifyOperatorAuth from './config/auth';
 
 config();
@@ -21,6 +22,7 @@ async function buildServer() {
   await server.register(verifyOperatorAuth);
   await server.register(adminRoutes, { prefix: '/admin' });
   await server.register(adminNotesRoutes, { prefix: '/admin' });
+  await server.register(adminSavedRepliesRoutes, { prefix: '/admin' });
   await server.register(adminStreamRoutes);
 
   server.get('/healthz', async () => ({ ok: true }));


### PR DESCRIPTION
## Summary
- add saved replies SQL table and indexes
- expose saved reply CRUD routes on gateway
- add drawer UI to manage and insert saved replies in operator admin

## Testing
- `npm test` (support-gateway)
- `npm test` (operator-admin)
- `npm run lint` (operator-admin, failed: ESLint setup prompt)

------
https://chatgpt.com/codex/tasks/task_e_6897905c9f848324adcdaaa493d99f61