### PR TITLE
feat: add conversation categories

### DIFF
--- a/infrastructure/005_add_categories.sql
+++ b/infrastructure/005_add_categories.sql
@@ -1,0 +1,11 @@
+-- 005_add_categories.sql
+CREATE TABLE IF NOT EXISTS categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  color TEXT DEFAULT '#4f46e5'
+);
+
+ALTER TABLE conversations
+  ADD COLUMN category_id UUID REFERENCES categories(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS conversations_category_id_idx ON conversations(category_id);

--- a/packages/operator-admin/src/app/conversations/[id]/page.tsx
+++ b/packages/operator-admin/src/app/conversations/[id]/page.tsx
@@ -7,17 +7,21 @@ import ChatView from '../../../components/ChatView';
 import MessageInput from '../../../components/MessageInput';
 import NotesPanel from '../../../components/NotesPanel';
 import { api } from '../../../lib/api';
+import CategoryBadge from '../../../components/CategoryBadge';
 
 interface Conversation {
   id: string;
   status: string;
   handoff: 'human' | 'bot';
+  category?: { id: string; name: string; color?: string } | null;
 }
 
 export default function ConversationPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const [conversation, setConversation] = useState<Conversation | null>(null);
   const [toast, setToast] = useState('');
+  const [categories, setCategories] = useState<{ id: string; name: string }[]>([]);
+  const [editingCategory, setEditingCategory] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -44,6 +48,33 @@ export default function ConversationPage({ params }: { params: { id: string } })
     }
   };
 
+  const handleEditCategory = async () => {
+    if (categories.length === 0) {
+      const res = await api('/admin/categories');
+      if (res.ok) {
+        const data = await res.json();
+        setCategories(data);
+      }
+    }
+    setEditingCategory(true);
+  };
+
+  const handleCategoryChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const category_id = e.target.value === 'none' ? null : e.target.value;
+    const res = await api(`/admin/conversations/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category_id }),
+    });
+    if (res.ok) {
+      const selected = categories.find((c) => c.id === category_id);
+      setConversation((prev) =>
+        prev ? { ...prev, category: selected || null } : prev
+      );
+    }
+    setEditingCategory(false);
+  };
+
   return (
     <AuthGuard>
       <div className="flex flex-col h-screen p-4">
@@ -58,12 +89,39 @@ export default function ConversationPage({ params }: { params: { id: string } })
             {conversation && (
               <div className="text-sm text-gray-600">
                 status: {conversation.status}, handoff: {conversation.handoff}
+                {conversation.category && (
+                  <span className="ml-2">
+                    <CategoryBadge
+                      name={conversation.category.name}
+                      color={conversation.category.color}
+                    />
+                  </span>
+                )}
               </div>
             )}
           </div>
-          {conversation?.handoff === 'human' && (
-            <Button onClick={handleReturn}>Вернуть боту</Button>
-          )}
+          <div className="flex items-center gap-2">
+            {conversation?.handoff === 'human' && (
+              <Button onClick={handleReturn}>Вернуть боту</Button>
+            )}
+            <Button variant="secondary" onClick={handleEditCategory}>
+              Изменить категорию
+            </Button>
+            {editingCategory && (
+              <select
+                className="border p-1 rounded"
+                onChange={handleCategoryChange}
+                defaultValue={conversation?.category?.id ?? 'none'}
+              >
+                <option value="none">Без категории</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
         </div>
         <div className="flex-1 flex flex-col md:flex-row gap-4 mb-4 overflow-hidden">
           <div className="flex-1 flex flex-col">

--- a/packages/operator-admin/src/app/conversations/page.tsx
+++ b/packages/operator-admin/src/app/conversations/page.tsx
@@ -5,11 +5,13 @@ import AuthGuard from '../../components/AuthGuard';
 import ConversationFilters from '../../components/ConversationFilters';
 import ConversationList from '../../components/ConversationList';
 import { connectSSE } from '../../lib/stream';
+import { api } from '../../lib/api';
 
 interface Filters {
   status?: string;
   handoff?: string;
   search?: string;
+  categoryId?: string;
 }
 
 export default function ConversationsPage() {
@@ -17,8 +19,10 @@ export default function ConversationsPage() {
     status: 'open',
     handoff: 'human',
     search: '',
+    categoryId: 'all',
   });
   const [stream, setStream] = useState<EventSource | null>(null);
+  const [categories, setCategories] = useState<{ id: string; name: string }[]>([]);
 
   useEffect(() => {
     const s = connectSSE();
@@ -26,6 +30,17 @@ export default function ConversationsPage() {
     return () => {
       s.close();
     };
+  }, []);
+
+  useEffect(() => {
+    const loadCats = async () => {
+      const res = await api('/admin/categories');
+      if (res.ok) {
+        const data = await res.json();
+        setCategories(data);
+      }
+    };
+    loadCats();
   }, []);
 
   const handleChange = (f: Filters) => {
@@ -36,16 +51,42 @@ export default function ConversationsPage() {
     <AuthGuard>
       <div className="p-4">
         <h1 className="text-2xl font-bold mb-4">Диалоги</h1>
+        <div className="flex gap-2 mb-2">
+          <button
+            className={`px-3 py-1 border rounded ${
+              !filters.categoryId || filters.categoryId === 'all'
+                ? 'bg-gray-200'
+                : ''
+            }`}
+            onClick={() => handleChange({ categoryId: 'all' })}
+          >
+            All
+          </button>
+          {categories.slice(0, 5).map((c) => (
+            <button
+              key={c.id}
+              className={`px-3 py-1 border rounded ${
+                filters.categoryId === c.id ? 'bg-gray-200' : ''
+              }`}
+              onClick={() => handleChange({ categoryId: c.id })}
+            >
+              {c.name}
+            </button>
+          ))}
+        </div>
         <ConversationFilters
           status={filters.status}
           handoff={filters.handoff}
           search={filters.search}
+           categoryId={filters.categoryId}
+           categories={categories}
           onChange={handleChange}
         />
         <ConversationList
           status={filters.status}
           handoff={filters.handoff}
           search={filters.search}
+          categoryId={filters.categoryId}
           stream={stream}
         />
       </div>

--- a/packages/operator-admin/src/components/CategoryBadge.tsx
+++ b/packages/operator-admin/src/components/CategoryBadge.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+interface CategoryBadgeProps {
+  name: string;
+  color?: string;
+}
+
+export default function CategoryBadge({ name, color = '#4f46e5' }: CategoryBadgeProps) {
+  return (
+    <span
+      className="px-2 py-1 rounded text-white text-xs"
+      style={{ backgroundColor: color }}
+    >
+      {name}
+    </span>
+  );
+}

--- a/packages/operator-admin/src/components/ConversationFilters.tsx
+++ b/packages/operator-admin/src/components/ConversationFilters.tsx
@@ -6,13 +6,22 @@ interface ConversationFiltersProps {
   status?: string;
   handoff?: string;
   search?: string;
-  onChange: (filters: { status?: string; handoff?: string; search?: string }) => void;
+  categoryId?: string;
+  categories?: { id: string; name: string }[];
+  onChange: (filters: {
+    status?: string;
+    handoff?: string;
+    search?: string;
+    categoryId?: string;
+  }) => void;
 }
 
 export default function ConversationFilters({
   status = 'all',
   handoff = 'all',
   search = '',
+  categoryId = 'all',
+  categories = [],
   onChange,
 }: ConversationFiltersProps) {
   const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -25,6 +34,10 @@ export default function ConversationFilters({
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange({ status, handoff, search: e.target.value });
+  };
+
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange({ status, handoff, search, categoryId: e.target.value });
   };
 
   return (
@@ -53,6 +66,18 @@ export default function ConversationFilters({
         onChange={handleSearchChange}
         className="max-w-xs"
       />
+      <select
+        className="border p-2 rounded"
+        value={categoryId}
+        onChange={handleCategoryChange}
+      >
+        <option value="all">Все категории</option>
+        {categories.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/packages/support-gateway/src/routes/admin.categories.ts
+++ b/packages/support-gateway/src/routes/admin.categories.ts
@@ -1,0 +1,74 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import supabase from '../db';
+
+export default async function adminCategoriesRoutes(server: FastifyInstance) {
+  server.addHook('preHandler', server.verifyOperatorAuth);
+
+  server.get('/categories', async (_req, reply) => {
+    const { data, error } = await supabase
+      .from('categories')
+      .select('id, name, color')
+      .order('name');
+    if (error) {
+      reply.code(500).send({ error: error.message });
+      return;
+    }
+    reply.send(data);
+  });
+
+  server.post('/categories', async (request, reply) => {
+    const bodySchema = z.object({
+      name: z.string(),
+      color: z.string().default('#4f46e5'),
+    });
+    const payload = bodySchema.parse(request.body);
+
+    const { data, error } = await supabase
+      .from('categories')
+      .insert(payload)
+      .select('id, name, color')
+      .single();
+
+    if (error || !data) {
+      reply.code(500).send({ error: error?.message });
+      return;
+    }
+    reply.send(data);
+  });
+
+  server.patch('/categories/:id', async (request, reply) => {
+    const paramsSchema = z.object({ id: z.string() });
+    const bodySchema = z
+      .object({ name: z.string().optional(), color: z.string().optional() })
+      .refine((d) => Object.keys(d).length > 0, { message: 'No fields to update' });
+
+    const { id } = paramsSchema.parse(request.params);
+    const payload = bodySchema.parse(request.body);
+
+    const { data, error } = await supabase
+      .from('categories')
+      .update(payload)
+      .eq('id', id)
+      .select('id, name, color')
+      .single();
+
+    if (error || !data) {
+      reply.code(500).send({ error: error?.message });
+      return;
+    }
+    reply.send(data);
+  });
+
+  server.delete('/categories/:id', async (request, reply) => {
+    const paramsSchema = z.object({ id: z.string() });
+    const { id } = paramsSchema.parse(request.params);
+
+    const { error } = await supabase.from('categories').delete().eq('id', id);
+    if (error) {
+      reply.code(500).send({ error: error.message });
+      return;
+    }
+    reply.send({ ok: true });
+  });
+}

--- a/packages/support-gateway/src/server.ts
+++ b/packages/support-gateway/src/server.ts
@@ -6,6 +6,7 @@ import logger from './utils/logger';
 import bot from './bot';
 import { generateResponse } from './services/ragService';
 import adminRoutes from './routes/admin.conversations';
+import adminCategoriesRoutes from './routes/admin.categories';
 import adminStreamRoutes from './routes/admin.stream';
 import adminNotesRoutes from './routes/admin.notes';
 import adminSavedRepliesRoutes from './routes/admin.saved-replies';
@@ -23,6 +24,7 @@ async function buildServer() {
   await server.register(multipart);
   await server.register(verifyOperatorAuth);
   await server.register(adminRoutes, { prefix: '/admin' });
+  await server.register(adminCategoriesRoutes, { prefix: '/admin' });
   await server.register(adminNotesRoutes, { prefix: '/admin' });
   await server.register(adminSavedRepliesRoutes, { prefix: '/admin' });
   await server.register(adminStreamRoutes);


### PR DESCRIPTION
## Summary
- support CRUD routes for conversation categories
- allow setting and filtering categories on conversations
- show category badges and filters in operator UI

## Testing
- `npm test` *(fails: Jest "global" coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68979f2c7e4083248e542de1678575a3