### PR TITLE
feat: add operator notification settings

### DIFF
--- a/packages/operator-admin/src/app/layout.tsx
+++ b/packages/operator-admin/src/app/layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout({
           <nav className="flex gap-4 items-center">
             <Link href="/conversations">Диалоги</Link>
             <Link href="/ask-bot">Спросить у бота</Link>
+            <Link href="/settings">Настройки</Link>
             <button onClick={handleLogout}>Выход</button>
           </nav>
         </header>

--- a/packages/operator-admin/src/app/settings/page.tsx
+++ b/packages/operator-admin/src/app/settings/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { requestPermission } from '../../lib/notifications';
+
+export default function SettingsPage() {
+  const [sound, setSound] = useState(false);
+  const [desktop, setDesktop] = useState(false);
+  const [assigned, setAssigned] = useState(false);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    setSound(localStorage.getItem('soundOn') === '1');
+    setDesktop(localStorage.getItem('desktopNotify') === '1');
+    setAssigned(localStorage.getItem('notifyAssigned') === '1');
+    setName(localStorage.getItem('operatorName') || '');
+  }, []);
+
+  const handleSound = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setSound(val);
+    localStorage.setItem('soundOn', val ? '1' : '0');
+  };
+
+  const handleDesktop = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setDesktop(val);
+    localStorage.setItem('desktopNotify', val ? '1' : '0');
+    if (val) requestPermission();
+  };
+
+  const handleAssigned = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setAssigned(val);
+    localStorage.setItem('notifyAssigned', val ? '1' : '0');
+  };
+
+  const handleName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setName(val);
+    localStorage.setItem('operatorName', val);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Настройки</h1>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={sound} onChange={handleSound} />
+        Звук при новых сообщениях
+      </label>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={desktop} onChange={handleDesktop} />
+        Desktop-уведомления
+      </label>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={assigned} onChange={handleAssigned} />
+        Уведомлять, когда мне назначен чат
+      </label>
+      <div>
+        <label className="block mb-1">Имя оператора</label>
+        <input
+          type="text"
+          value={name}
+          onChange={handleName}
+          className="border p-1 rounded w-full max-w-sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/operator-admin/src/lib/notifications.ts
+++ b/packages/operator-admin/src/lib/notifications.ts
@@ -1,0 +1,35 @@
+'use client';
+
+export function requestPermission() {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  if (Notification.permission === 'default') {
+    Notification.requestPermission();
+  }
+}
+
+export function notify(title: string, body: string) {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  if (Notification.permission === 'granted') {
+    new Notification(title, { body });
+  }
+}
+
+export function playBeep() {
+  if (typeof window === 'undefined') return;
+  try {
+    const Ctx = (window.AudioContext || (window as any).webkitAudioContext);
+    const ctx = new Ctx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = 880;
+    gain.gain.value = 0.1;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.2);
+    osc.onended = () => ctx.close();
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/packages/operator-admin/src/lib/stream.ts
+++ b/packages/operator-admin/src/lib/stream.ts
@@ -1,10 +1,44 @@
 'use client';
 
+import { notify, playBeep, requestPermission } from './notifications';
+
 export function connectSSE() {
   const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  if (typeof window !== 'undefined' && localStorage.getItem('desktopNotify') === '1') {
+    requestPermission();
+  }
   const url = token
     ? `${base}/admin/stream?token=${encodeURIComponent(token)}`
     : `${base}/admin/stream`;
-  return new EventSource(url);
+  const es = new EventSource(url);
+
+  es.addEventListener('user_msg', (e) => {
+    try {
+      if (typeof window === 'undefined') return;
+      const data = JSON.parse((e as MessageEvent).data);
+      if (localStorage.getItem('soundOn') === '1') {
+        playBeep();
+      }
+      if (localStorage.getItem('desktopNotify') === '1') {
+        notify('Новое сообщение', data.content || '');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  es.addEventListener('assigned', (e) => {
+    try {
+      if (typeof window === 'undefined') return;
+      const data = JSON.parse((e as MessageEvent).data);
+      if (localStorage.getItem('notifyAssigned') === '1') {
+        notify('Чат назначен вам', data.conversation_id ? `Чат ${data.conversation_id}` : '');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  return es;
 }


### PR DESCRIPTION
## Summary
- add settings page to control sound, desktop alerts, assignment notifications and operator name
- implement notification utilities and integrate with SSE
- show settings link in layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a1a302d48324b096887df5490a4f