### PR TITLE
feat: add conversation assignee workflow

### DIFF
--- a/infrastructure/007_add_conversation_assignee.sql
+++ b/infrastructure/007_add_conversation_assignee.sql
@@ -1,0 +1,4 @@
+-- 007_add_conversation_assignee.sql
+ALTER TABLE conversations
+  ADD COLUMN assignee_name TEXT,
+  ADD COLUMN assigned_at TIMESTAMPTZ;

--- a/packages/operator-admin/src/app/conversations/[id]/page.tsx
+++ b/packages/operator-admin/src/app/conversations/[id]/page.tsx
@@ -9,12 +9,14 @@ import NotesPanel from '../../../components/NotesPanel';
 import { api } from '../../../lib/api';
 import CategoryBadge from '../../../components/CategoryBadge';
 import CreateCaseModal from '../../../components/CreateCaseModal';
+import { connectSSE } from '../../../lib/stream';
 
 interface Conversation {
   id: string;
   status: string;
   handoff: 'human' | 'bot';
   category?: { id: string; name: string; color?: string } | null;
+  assignee_name?: string | null;
 }
 
 export default function ConversationPage({ params }: { params: { id: string } }) {
@@ -24,6 +26,8 @@ export default function ConversationPage({ params }: { params: { id: string } })
   const [categories, setCategories] = useState<{ id: string; name: string }[]>([]);
   const [editingCategory, setEditingCategory] = useState(false);
   const [showCaseModal, setShowCaseModal] = useState(false);
+  const operatorName =
+    typeof window !== 'undefined' ? localStorage.getItem('operatorName') : null;
 
   useEffect(() => {
     const load = async () => {
@@ -34,6 +38,19 @@ export default function ConversationPage({ params }: { params: { id: string } })
       }
     };
     load();
+
+    const es = connectSSE();
+    es.addEventListener('assigned', (e) => {
+      const data = JSON.parse((e as MessageEvent).data);
+      if (data.conversation_id === id) {
+        setConversation((prev) =>
+          prev ? { ...prev, assignee_name: data.assignee_name } : prev
+        );
+      }
+    });
+    return () => {
+      es.close();
+    };
   }, [id]);
 
   const handleReturn = async () => {
@@ -77,6 +94,35 @@ export default function ConversationPage({ params }: { params: { id: string } })
     setEditingCategory(false);
   };
 
+  const handleClaim = async () => {
+    if (!operatorName) return;
+    const res = await api(`/admin/conversations/${id}/claim`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignee_name: operatorName }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setConversation((prev) =>
+        prev ? { ...prev, assignee_name: data.assignee_name } : prev
+      );
+    }
+  };
+
+  const handleTakeover = async () => {
+    if (!operatorName) return;
+    const res = await api(`/admin/conversations/${id}/takeover`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignee_name: operatorName }),
+    });
+    if (res.ok) {
+      setConversation((prev) =>
+        prev ? { ...prev, assignee_name: operatorName } : prev
+      );
+    }
+  };
+
   return (
     <AuthGuard>
       <div className="flex flex-col h-screen p-4">
@@ -88,21 +134,35 @@ export default function ConversationPage({ params }: { params: { id: string } })
         <div className="mb-4 flex items-center justify-between">
           <div>
             <h1 className="text-xl font-bold">Диалог {id}</h1>
-            {conversation && (
-              <div className="text-sm text-gray-600">
-                status: {conversation.status}, handoff: {conversation.handoff}
-                {conversation.category && (
-                  <span className="ml-2">
-                    <CategoryBadge
-                      name={conversation.category.name}
-                      color={conversation.category.color}
-                    />
-                  </span>
-                )}
-              </div>
-            )}
+              {conversation && (
+                <div className="text-sm text-gray-600">
+                  status: {conversation.status}, handoff: {conversation.handoff}
+                  {conversation.assignee_name && (
+                    <span className="ml-2 px-2 py-0.5 bg-blue-100 rounded">
+                      Закреплён за: {conversation.assignee_name}
+                    </span>
+                  )}
+                  {conversation.category && (
+                    <span className="ml-2">
+                      <CategoryBadge
+                        name={conversation.category.name}
+                        color={conversation.category.color}
+                      />
+                    </span>
+                  )}
+                </div>
+              )}
           </div>
           <div className="flex items-center gap-2">
+            {conversation?.assignee_name ? (
+              conversation.assignee_name === operatorName ? null : (
+                <Button variant="secondary" onClick={handleTakeover}>
+                  Перехватить
+                </Button>
+              )
+            ) : (
+              <Button onClick={handleClaim}>Ответить</Button>
+            )}
             {conversation?.handoff === 'human' && (
               <Button onClick={handleReturn}>Вернуть боту</Button>
             )}
@@ -131,9 +191,15 @@ export default function ConversationPage({ params }: { params: { id: string } })
         <div className="flex-1 flex flex-col md:flex-row gap-4 mb-4 overflow-hidden">
           <div className="flex-1 flex flex-col">
             <div className="flex-1 overflow-y-auto mb-4">
-              <ChatView conversationId={id} initialHandoff={conversation?.handoff === 'human'} />
+              <ChatView
+                conversationId={id}
+                initialHandoff={conversation?.handoff === 'human'}
+              />
             </div>
-            <MessageInput conversationId={id} />
+            <MessageInput
+              conversationId={id}
+              assigneeName={conversation?.assignee_name}
+            />
           </div>
           <div className="md:w-80 w-full flex-shrink-0 overflow-y-auto">
             <NotesPanel conversationId={id} />

--- a/packages/operator-admin/src/app/conversations/page.tsx
+++ b/packages/operator-admin/src/app/conversations/page.tsx
@@ -12,6 +12,7 @@ interface Filters {
   handoff?: string;
   search?: string;
   categoryId?: string;
+  mine?: boolean;
 }
 
 export default function ConversationsPage() {
@@ -20,6 +21,7 @@ export default function ConversationsPage() {
     handoff: 'human',
     search: '',
     categoryId: 'all',
+    mine: false,
   });
   const [stream, setStream] = useState<EventSource | null>(null);
   const [categories, setCategories] = useState<{ id: string; name: string }[]>([]);
@@ -78,8 +80,9 @@ export default function ConversationsPage() {
           status={filters.status}
           handoff={filters.handoff}
           search={filters.search}
-           categoryId={filters.categoryId}
-           categories={categories}
+          categoryId={filters.categoryId}
+          categories={categories}
+          mine={filters.mine}
           onChange={handleChange}
         />
         <ConversationList
@@ -87,6 +90,7 @@ export default function ConversationsPage() {
           handoff={filters.handoff}
           search={filters.search}
           categoryId={filters.categoryId}
+          mine={filters.mine}
           stream={stream}
         />
       </div>

--- a/packages/operator-admin/src/components/ConversationFilters.tsx
+++ b/packages/operator-admin/src/components/ConversationFilters.tsx
@@ -13,7 +13,9 @@ interface ConversationFiltersProps {
     handoff?: string;
     search?: string;
     categoryId?: string;
+    mine?: boolean;
   }) => void;
+  mine?: boolean;
 }
 
 export default function ConversationFilters({
@@ -23,21 +25,26 @@ export default function ConversationFilters({
   categoryId = 'all',
   categories = [],
   onChange,
+  mine = false,
 }: ConversationFiltersProps) {
   const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange({ status: e.target.value, handoff, search });
+    onChange({ status: e.target.value, handoff, search, categoryId, mine });
   };
 
   const handleHandoffChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange({ status, handoff: e.target.value, search });
+    onChange({ status, handoff: e.target.value, search, categoryId, mine });
   };
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange({ status, handoff, search: e.target.value });
+    onChange({ status, handoff, search: e.target.value, categoryId, mine });
   };
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange({ status, handoff, search, categoryId: e.target.value });
+    onChange({ status, handoff, search, categoryId: e.target.value, mine });
+  };
+
+  const handleMineChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ status, handoff, search, categoryId, mine: e.target.checked });
   };
 
   return (
@@ -78,6 +85,10 @@ export default function ConversationFilters({
           </option>
         ))}
       </select>
+      <label className="flex items-center space-x-1">
+        <input type="checkbox" checked={mine} onChange={handleMineChange} />
+        <span>Мои</span>
+      </label>
     </div>
   );
 }

--- a/packages/support-gateway/src/routes/admin.stream.ts
+++ b/packages/support-gateway/src/routes/admin.stream.ts
@@ -26,11 +26,14 @@ export default async function adminStreamRoutes(server: FastifyInstance) {
         send('op_reply', p);
       const mediaUpd = (p: { message_id: number; kind: 'transcript' | 'vision' }) =>
         send('media_upd', p);
+      const assigned = (p: { conversation_id: number; assignee_name: string }) =>
+        send('assigned', p);
 
       liveBus.on('handoff', handoff);
       liveBus.on('new_user_msg', newUser);
       liveBus.on('operator_reply', opReply);
       liveBus.on('media_updated', mediaUpd);
+      liveBus.on('assigned', assigned);
 
       request.raw.on('close', () => {
         clearInterval(ping);
@@ -38,6 +41,7 @@ export default async function adminStreamRoutes(server: FastifyInstance) {
         liveBus.off('new_user_msg', newUser);
         liveBus.off('operator_reply', opReply);
         liveBus.off('media_updated', mediaUpd);
+        liveBus.off('assigned', assigned);
       });
     }
   );


### PR DESCRIPTION
## Summary
- add assignee fields to conversations schema
- implement claim/takeover routes with assignment checks
- display and filter conversations by assignee in admin UI

## Testing
- `npm test` *(fails: Jest "global" coverage threshold for statements (60%) not met: 33.17%)*

------
https://chatgpt.com/codex/tasks/task_e_6897a53e1cb08324a3d2fa5f3d8c3f07