### PR TITLE
feat: add operator ask-bot chat

### DIFF
--- a/packages/operator-admin/src/app/ask-bot/page.tsx
+++ b/packages/operator-admin/src/app/ask-bot/page.tsx
@@ -1,10 +1,95 @@
+'use client';
+
+import { useState } from 'react';
 import AuthGuard from '../../components/AuthGuard';
+import { api } from '../../lib/api';
+import { Button } from '@shadcn/ui/button';
+import { Input } from '@shadcn/ui/input';
+
+interface ChatMessage {
+  role: 'operator' | 'bot';
+  content: string;
+  created_at: string;
+}
 
 export default function AskBotPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const roleBg = (role: ChatMessage['role']) =>
+    role === 'operator' ? 'bg-blue-100' : 'bg-green-100';
+
+  const handleSend = async () => {
+    if (!text.trim() || sending) return;
+    const question = text;
+    setMessages((prev) => [
+      ...prev,
+      { role: 'operator', content: question, created_at: new Date().toISOString() },
+    ]);
+    setText('');
+    setSending(true);
+    try {
+      const res = await api('/admin/ask-bot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages((prev) => [
+          ...prev,
+          { role: 'bot', content: data.answer, created_at: new Date().toISOString() },
+        ]);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          { role: 'bot', content: 'Ошибка сервера', created_at: new Date().toISOString() },
+        ]);
+      }
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        { role: 'bot', content: 'Сеть недоступна', created_at: new Date().toISOString() },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
   return (
     <AuthGuard>
       <div className="p-4">
         <h1 className="text-2xl font-bold mb-4">Спросить у бота</h1>
+        <div className="space-y-2 mb-4">
+          {messages.map((m, i) => (
+            <div key={i} className={`p-2 rounded ${roleBg(m.role)}`}>
+              <div className="text-xs text-gray-600 mb-1">
+                {new Date(m.created_at).toLocaleString()} — {m.role}
+              </div>
+              <div>{m.content}</div>
+            </div>
+          ))}
+        </div>
+        <div className="flex space-x-2">
+          <Input
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKey}
+            placeholder="Введите вопрос"
+            className="flex-1"
+          />
+          <Button onClick={handleSend} disabled={sending}>
+            Отправить
+          </Button>
+        </div>
       </div>
     </AuthGuard>
   );

--- a/packages/support-gateway/src/routes/admin.ask-bot.ts
+++ b/packages/support-gateway/src/routes/admin.ask-bot.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance } from 'fastify';
+
+export default async function adminAskBotRoutes(server: FastifyInstance) {
+  server.addHook('preHandler', server.verifyOperatorAuth);
+
+  server.post('/ask-bot', async (_request, reply) => {
+    reply.send({ answer: 'Заглушка: бот ещё не подключён' });
+  });
+}

--- a/packages/support-gateway/src/server.ts
+++ b/packages/support-gateway/src/server.ts
@@ -11,6 +11,7 @@ import adminStreamRoutes from './routes/admin.stream';
 import adminNotesRoutes from './routes/admin.notes';
 import adminSavedRepliesRoutes from './routes/admin.saved-replies';
 import adminCasesRoutes from './routes/admin.cases';
+import adminAskBotRoutes from './routes/admin.ask-bot';
 import verifyOperatorAuth from './config/auth';
 
 config();
@@ -29,6 +30,7 @@ async function buildServer() {
   await server.register(adminNotesRoutes, { prefix: '/admin' });
   await server.register(adminSavedRepliesRoutes, { prefix: '/admin' });
   await server.register(adminCasesRoutes, { prefix: '/admin' });
+  await server.register(adminAskBotRoutes, { prefix: '/admin' });
   await server.register(adminStreamRoutes);
 
   server.get('/healthz', async () => ({ ok: true }));


### PR DESCRIPTION
## Summary
- add operator ask-bot page with simple chat UI and state history
- create protected /admin/ask-bot fastify route and register in server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b0ea7d688324a031486ef50dee8d