### PR TITLE
feat: restrict telegram webhook IPs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "googleapis": "^136.0.0",
         "helmet": "^7.1.0",
         "hnswlib-node": "^3.0.0",
+        "ip-range-check": "0.2.0",
         "ipaddr.js": "^2.2.0",
         "jsdom": "^24.0.0",
         "multer": "^2.0.2",
@@ -1982,6 +1983,24 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-range-check": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+      "integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+      "license": "MIT",
+      "dependencies": {
+        "ipaddr.js": "^1.0.1"
+      }
+    },
+    "node_modules/ip-range-check/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "googleapis": "^136.0.0",
     "helmet": "^7.1.0",
     "hnswlib-node": "^3.0.0",
+    "ip-range-check": "0.2.0",
     "ipaddr.js": "^2.2.0",
     "jsdom": "^24.0.0",
     "multer": "^2.0.2",
@@ -56,7 +57,6 @@
     "web-push": "^3.6.6",
     "yaml": "^2.5.0"
   },
-  "devDependencies": {},
   "overrides": {
     "formdata-node": "^6.0.3"
   }


### PR DESCRIPTION
## Summary
- allow only known IP ranges for Telegram webhook
- add ip-range-check dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c551dd08832492c7c77ffcd87eb8