### PR TITLE
fix: make preinstall cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docker:run": "docker run --rm -p 3000:3000 --env-file .env -v $PWD/data:/app/data -v $PWD/logs:/app/logs -v $PWD/feedback:/app/feedback my-support-bot:latest",
     "sem:rebuild": "node -e \"(async()=>{const s=require('./src/semantic/index');if(s.rebuildAll){console.log(await s.rebuildAll())}})()\"",
     "rag:reindex": "node -e \"(async()=>{const r=require('./src/rag/index');if(r.rebuildAll){console.log(await r.rebuildAll())}})()\"",
-    "preinstall": "if [ \"$NODE_ENV\" != \"production\" ]; then node scripts/preinstall.js; fi"
+    "preinstall": "node scripts/preinstall.js"
   },
   "dependencies": {
     "@xenova/transformers": "^2.17.2",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,1 +1,6 @@
-console.log("[preinstall] no-op script for production build");
+if (process.env.NODE_ENV === 'production') {
+  console.log('[preinstall] skipping script in production environment');
+  process.exit(0);
+}
+
+console.log('[preinstall] no-op script for non-production environments');


### PR DESCRIPTION
## Summary
- handle NODE_ENV check inside `scripts/preinstall.js`
- simplify `preinstall` script in `package.json` for cross-platform compatibility

## Testing
- `npm test`
- `npm run lint`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68988190400083249c16b2a6481c8807