### PR TITLE
Handle missing OpenAI API key

### DIFF
--- a/src/llm/fallback.js
+++ b/src/llm/fallback.js
@@ -4,10 +4,21 @@ const { logger } = require('../utils/logger');
 
 dotenv.config();
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const apiKey = process.env.OPENAI_API_KEY;
+let client = null;
+
+if (apiKey) {
+  client = new OpenAI({ apiKey });
+} else {
+  logger.warn('OPENAI_API_KEY is not set; OpenAI fallback disabled');
+}
 
 async function fallbackQuery(question, lang) {
   if (!question) {
+    return '';
+  }
+  if (!client) {
+    logger.error('OpenAI client not initialized');
     return '';
   }
   try {

--- a/src/rag/answerer.js
+++ b/src/rag/answerer.js
@@ -1,7 +1,15 @@
 const OpenAI = require('openai');
 const { logger } = require('../utils/logger');
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const apiKey = process.env.OPENAI_API_KEY;
+let client = null;
+
+if (apiKey) {
+  client = new OpenAI({ apiKey });
+} else {
+  logger.warn('OPENAI_API_KEY is not set; RAG answering disabled');
+}
+
 const MODEL = process.env.RAG_OPENAI_MODEL || 'gpt-4o-mini';
 const TEMP = Number(process.env.RAG_TEMPERATURE || '0.2');
 const DEFAULT_LANG = process.env.DEFAULT_LANG || 'en';
@@ -13,6 +21,10 @@ async function answerWithRag({ question, lang, contextText, citations }) {
     .map((c, i) => `${i + 1}. ${c.title || c.sourceId}`)
     .join('\n');
   const user = `Вопрос: ${question}\nКонтекст:\n---\n${contextText}\n---\nИсточники:\n${srcList}\nЯзык ответа: ${lang || DEFAULT_LANG}`;
+  if (!client) {
+    logger.error('OpenAI client not initialized');
+    throw new Error('OPENAI_API_KEY not configured');
+  }
   try {
     const completion = await client.chat.completions.create({
       model: MODEL,


### PR DESCRIPTION
## Summary
- Avoid server crash when `OPENAI_API_KEY` is unset
- Guard fallback and RAG logic behind optional OpenAI client

## Testing
- `npm test`
- `npm run lint`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_689882b12d208324ae2832418aff30f8