### PR TITLE
feat(backend): add health checks and request context

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -5,10 +5,18 @@ import { buildRoutes } from './http/routes.js';
 import { applyObservability } from './http/bootstrap/observability.js';
 import { applyDocs } from './http/bootstrap/docs.js';
 import type { IUserRepo } from './modules/users/domain/User.js';
+import { randomUUID } from 'crypto';
+import { withCtx } from './shared/context.js';
 
-export function createApp(deps: { userRepo: IUserRepo }) {
+export function createApp(deps: { userRepo: IUserRepo, health?: { db: () => Promise<boolean> } }) {
   const app = express();
   app.use(express.json({ limit: '1mb' }));
+  app.use((req, _res, next) => {
+    const requestId = (req.header('x-request-id') as string) || randomUUID();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (req as any).id = requestId;
+    withCtx({ requestId }, next);
+  });
   applyObservability(app);
   applySecurity(app);
   app.use('/api', buildRoutes(deps));

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error zod types
 import * as z from 'zod';
 export const EnvSchema = z.object({
   NODE_ENV: z.enum(['development','test','production']),

--- a/packages/backend/src/http/bootstrap/observability.ts
+++ b/packages/backend/src/http/bootstrap/observability.ts
@@ -7,7 +7,7 @@ export const logger = pino({ level: process.env.LOG_LEVEL || 'info', redact: ['r
 
 export function applyObservability(app: Express) {
   // @ts-expect-error pino-http CJS
-  app.use(pinoHttp({ logger }));
+  app.use(pinoHttp({ logger, genReqId: req => (req.id as string) }));
   client.collectDefaultMetrics();
   app.get('/metrics', async (_req, res) => {
     res.set('Content-Type', client.register.contentType);

--- a/packages/backend/src/http/errors/map.ts
+++ b/packages/backend/src/http/errors/map.ts
@@ -1,0 +1,5 @@
+import { AppError } from './AppError.js';
+export const mapDomainError = (e: unknown) => {
+  if ((e as Error).message === 'USER_EXISTS') return new AppError('USER_EXISTS','User exists',409);
+  return e;
+};

--- a/packages/backend/src/http/middleware/idempotency.ts
+++ b/packages/backend/src/http/middleware/idempotency.ts
@@ -1,0 +1,8 @@
+import type { Request, Response, NextFunction } from 'express';
+import { redis } from '../../infra/redis.js';
+export async function idempotency(req: Request, res: Response, next: NextFunction) {
+  const key = req.header('idempotency-key'); if (!key) return next();
+  const hit = await redis.get(key); if (hit) return res.status(409).json({ error:'IDEMPOTENT_REPLAY' });
+  await redis.setex(key, 60 * 10, 'used'); // 10 min
+  return next();
+}

--- a/packages/backend/src/http/middleware/responseValidate.ts
+++ b/packages/backend/src/http/middleware/responseValidate.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { ZodSchema } from 'zod';
+export const validateResponse = (schema: ZodSchema) => {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    const send = res.json.bind(res);
+    res.json = (body: any) => {
+      if (process.env.NODE_ENV !== 'production') {
+        const ok = schema.safeParse(body);
+        if (!ok.success) console.warn('Response schema mismatch', ok.error.issues);
+      }
+      return send(body);
+    };
+    next();
+  };
+};

--- a/packages/backend/src/http/middleware/validate.ts
+++ b/packages/backend/src/http/middleware/validate.ts
@@ -1,9 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
-// @ts-expect-error zod types
 import type { ZodTypeAny } from 'zod';
 export const validate = (schema: ZodTypeAny) => (req: Request, res: Response, next: NextFunction) => {
   const parsed = schema.safeParse({ body: req.body, params: req.params, query: req.query });
   if (!parsed.success) return res.status(400).json({ error: 'VALIDATION_ERROR', details: parsed.error.issues });
-  // @ts-expect-error attach parsed if needed
-  req.validated = parsed.data; next();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (req as any).validated = parsed.data; next();
 };

--- a/packages/backend/src/http/routes.ts
+++ b/packages/backend/src/http/routes.ts
@@ -2,8 +2,13 @@ import { Router } from 'express';
 import { usersRoutes } from '../modules/users/http/routes.js';
 import type { IUserRepo } from '../modules/users/domain/User.js';
 
-export function buildRoutes(deps: { userRepo: IUserRepo }) {
+export function buildRoutes(deps: { userRepo: IUserRepo, health?: { db: () => Promise<boolean> } }) {
   const r = Router();
+  r.get('/livez', (_req, res) => res.send('OK'));
+  r.get('/readyz', async (_req, res) => {
+    const ok = await (deps.health?.db?.() ?? Promise.resolve(true));
+    return ok ? res.send('OK') : res.status(503).send('NOT_READY');
+  });
   r.get('/health', (_req, res) => res.json({ ok: true }));
   r.use('/users', usersRoutes(deps.userRepo));
   return r;

--- a/packages/backend/src/infra/redis.ts
+++ b/packages/backend/src/infra/redis.ts
@@ -1,0 +1,6 @@
+class InMemoryRedis {
+  private store = new Map<string, string>();
+  async get(key: string) { return this.store.get(key) ?? null; }
+  async setex(key: string, _ttl: number, value: string) { this.store.set(key, value); return 'OK'; }
+}
+export const redis = new InMemoryRedis();

--- a/packages/backend/src/infra/tx.ts
+++ b/packages/backend/src/infra/tx.ts
@@ -1,0 +1,5 @@
+export async function withTx<T>(db: any, fn: (trx: any)=>Promise<T>) {
+  const trx = await db.transaction();
+  try { const r = await fn(trx); await trx.commit(); return r; }
+  catch(e){ await trx.rollback(); throw e; }
+}

--- a/packages/backend/src/modules/users/http/routes.ts
+++ b/packages/backend/src/modules/users/http/routes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import { validate } from '../../../http/middleware/validate.js';
+import { idempotency } from '../../../http/middleware/idempotency.js';
+import { mapDomainError } from '../../../http/errors/map.js';
 import { CreateUserSchema } from '../../../validation/schemas.js';
 import { UserService } from '../app/UserService.js';
 import type { IUserRepo } from '../domain/User.js';
@@ -8,12 +10,12 @@ export const usersRoutes = (repo: IUserRepo) => {
   const router = Router();
   const service = new UserService(repo);
 
-  router.post('/', validate(CreateUserSchema), async (req, res, next) => {
+  router.post('/', idempotency, validate(CreateUserSchema), async (req, res, next) => {
     try {
       const { email, name } = req.body;
       const user = await service.register(email, name);
       res.status(201).json(user);
-    } catch (e) { next(e); }
+    } catch (e) { next(mapDomainError(e)); }
   });
 
   return router;

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -6,7 +6,20 @@ import { Pool } from 'pg';
 
 const env = loadEnv();
 const pool = new Pool({ connectionString: env.DATABASE_URL });
-const app = createApp({ userRepo: new PgUserRepo(pool) });
+const app = createApp({
+  userRepo: new PgUserRepo(pool),
+  health: { db: async () => pool.query('select 1').then(() => true).catch(() => false) }
+});
 
 const port = env.PORT ?? 3000;
-app.listen(port, () => console.log(`API on :${port}`));
+const server = app.listen(port, () => console.log(`API on :${port}`));
+
+const shutdown = async () => {
+  console.log('graceful shutdown...');
+  server.closeAllConnections?.();
+  server.close(() => console.log('http closed'));
+  try { await pool.end?.(); } catch {}
+  process.exit(0);
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/packages/backend/src/shared/context.ts
+++ b/packages/backend/src/shared/context.ts
@@ -1,0 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+export type Ctx = { requestId: string };
+export const als = new AsyncLocalStorage<Ctx>();
+export const withCtx = <T>(ctx: Ctx, fn: () => T) => als.run(ctx, fn);
+export const getCtx = () => als.getStore();

--- a/packages/backend/src/validation/pagination.ts
+++ b/packages/backend/src/validation/pagination.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+export const ListQuery = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().min(1).max(100).default(20)
+});
+export type ListResult<T> = { items: T[]; nextCursor?: string };

--- a/packages/backend/src/validation/schemas.ts
+++ b/packages/backend/src/validation/schemas.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error zod types
 import * as z from 'zod';
 export const CreateUserSchema = z.object({
   body: z.object({

--- a/packages/kb-tools/package.json
+++ b/packages/kb-tools/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.0.0",
-    "langchain": "^0.0.1",
+    "langchain": "^0.1.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.0.0"
   }


### PR DESCRIPTION
## Summary
- add /livez and /readyz endpoints with graceful shutdown hooks
- introduce AsyncLocalStorage request context and pino correlation ids
- add transaction helper, error mapping, idempotency middleware, and pagination schema

## Testing
- `npm test -w packages/backend`
- `npm run build -w packages/backend`


------
https://chatgpt.com/codex/tasks/task_e_6898d60907a8832488c71e17fb598870