### PR TITLE
feat(bot): add intent classifier and RAG responses

### DIFF
--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -1,4 +1,11 @@
 import { Telegraf } from 'telegraf';
+import { createRequire } from 'node:module';
+import { logger } from '../utils/logger.js';
+import { intentClassifier } from './intent.js';
+
+const require = createRequire(import.meta.url);
+const { answerWithRag } = require('../rag/answerer.js');
+const { retrieve } = require('../rag/retriever.js');
 
 const token = process.env.TG_BOT_TOKEN;
 if (!token) {
@@ -12,10 +19,30 @@ bot.help((ctx) => ctx.reply('Доступно: /start, /help, /ticket'));
 bot.command('ticket', async (ctx) => {
   await ctx.reply('Опишите проблему одним сообщением. Мы создадим тикет и свяжемся 🙌');
 });
-bot.on('text', (ctx) => {
-  // эхо для отладки
-  ctx.reply(`Понял: "${ctx.message.text}"`);
+bot.on('text', async (ctx) => {
+  const text = ctx.message.text || '';
+  const intent = intentClassifier(text);
+  logger.info({ intent, text }, 'incoming message');
+  try {
+    if (intent === 'question') {
+      const { contextText, citations } = await retrieve(text);
+      const { answer } = await answerWithRag({
+        question: text,
+        lang: ctx.from?.language_code,
+        contextText,
+        citations
+      });
+      await ctx.reply(answer);
+    } else if (intent === 'ticket') {
+      await ctx.reply('Тикет создан, оператор скоро свяжется.');
+    } else {
+      await ctx.reply('Перенаправляю на оператора...');
+    }
+  } catch (err) {
+    logger.error({ err }, 'text handler failed');
+    await ctx.reply('Произошла ошибка. Попробуйте позже или используйте /ticket.');
+  }
 });
-bot.catch((err) => console.error('[bot.error]', err));
+bot.catch((err) => logger.error({ err }, 'bot error'));
 
 export default bot;

--- a/src/bot/intent.ts
+++ b/src/bot/intent.ts
@@ -1,0 +1,12 @@
+export type Intent = 'question' | 'ticket' | 'operator';
+
+export function intentClassifier(text: string): Intent {
+  const lower = text.toLowerCase();
+  if (lower.includes('оператор') || lower.includes('operator') || lower.includes('человек')) {
+    return 'operator';
+  }
+  if (lower.includes('ticket') || lower.includes('проблем') || lower.includes('ошибк')) {
+    return 'ticket';
+  }
+  return 'question';
+}


### PR DESCRIPTION
## Summary
- integrate RAG answerer and context retriever into Telegram bot
- add simple intent classifier to route messages
- enhance bot error handling and logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e64987148324b81bf9b8af31bdd1