### PR TITLE
feat: semantic search for FAQ

### DIFF
--- a/scripts/reindex-questions.ts
+++ b/scripts/reindex-questions.ts
@@ -1,0 +1,11 @@
+import { buildIndex } from '../src/search/semanticSearch';
+
+async function run() {
+  const count = await buildIndex();
+  console.log(`Reindexed ${count} questions`);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/search/semanticSearch.ts
+++ b/src/search/semanticSearch.ts
@@ -1,0 +1,65 @@
+import { OpenAIEmbeddings } from 'langchain/embeddings/openai';
+import { supabaseService } from '../database/connection';
+import { createStore } from '../data/store';
+
+const embedder = new OpenAIEmbeddings();
+const TABLE = 'faq_questions';
+const indexed = new Set<string>();
+
+export async function buildIndex(basePath?: string) {
+  const store = createStore(basePath);
+  const items = store.getApproved();
+  if (items.length === 0) return 0;
+  const texts = items.map((item) => {
+    const arr: string[] = [item.Question];
+    if (item.translations) {
+      for (const t of Object.values(item.translations)) {
+        if (t && t.Question) arr.push(t.Question);
+      }
+    }
+    return arr.join('\n');
+  });
+  const vectors = await embedder.embedDocuments(texts);
+  const records = items.map((item, i) => ({
+    id: item.id,
+    question: item.Question,
+    embedding: vectors[i]
+  }));
+  const { error } = await supabaseService.from(TABLE).upsert(records);
+  if (error) throw error;
+  if (basePath) {
+    indexed.add(basePath);
+    store.onUpdated(() => indexed.delete(basePath));
+  }
+  return records.length;
+}
+
+export async function semanticSearch(query: string, limit = 5, tenant?: any) {
+  if (!query) return [];
+  const basePath = tenant?.basePath;
+  if (basePath && !indexed.has(basePath)) {
+    await buildIndex(basePath);
+  }
+  const [queryVec] = await embedder.embedDocuments([query]);
+  const { data, error } = await supabaseService.rpc('match_faq_questions', {
+    query_embedding: queryVec,
+    match_count: limit
+  });
+  if (error || !data) return [];
+  const store = createStore(basePath);
+  return data.map((row: any) => {
+    const item = store.getById(row.id);
+    const sim = row.similarity ?? row.sim ?? 0;
+    return { item, score: 1 - sim, sim };
+  });
+}
+
+export async function getIndexSize() {
+  const { count, error } = await supabaseService
+    .from(TABLE)
+    .select('id', { count: 'exact', head: true });
+  if (error) return 0;
+  return count || 0;
+}
+
+export default { buildIndex, semanticSearch, getIndexSize };

--- a/src/support/support.js
+++ b/src/support/support.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
-const { fuzzySearch } = require('../search/fuzzySearch');
+const { semanticSearch } = require('../search/semanticSearch');
 const { fallbackQuery } = require('../llm/fallback');
 const { logger } = require('../utils/logger');
 const { createStore } = require('../data/store');
@@ -78,9 +78,9 @@ async function getAnswer(question, opts = {}) {
     return result;
   }
   try {
-    const fuzzyTop = fuzzySearch(question, TOPK, tenant);
+    const fuzzyTop = await semanticSearch(question, TOPK, tenant);
     const bestExact = fuzzyTop[0];
-    if (bestExact && bestExact.score === 0) {
+    if (bestExact && bestExact.sim >= 0.99) {
       const { questionText, answerTemplate } = selectLocalizedQA(
         bestExact.item,
         lang,

--- a/supabase/migrations/20250820120000_add_faq_questions.sql
+++ b/supabase/migrations/20250820120000_add_faq_questions.sql
@@ -1,0 +1,21 @@
+create table if not exists faq_questions (
+  id uuid primary key,
+  question text,
+  embedding vector(1536),
+  created_at timestamptz default now()
+);
+
+drop function if exists match_faq_questions;
+create function match_faq_questions(
+  query_embedding vector(1536),
+  match_count int
+)
+returns table(id uuid, question text, similarity float)
+language sql stable
+as $$
+  select id, question,
+         1 - (embedding <=> query_embedding) as similarity
+  from faq_questions
+  order by embedding <=> query_embedding
+  limit match_count;
+$$;


### PR DESCRIPTION
## Summary
- use OpenAI embeddings to index questions and store vectors in Supabase
- switch support flow from fuzzy search to semantic search based on cosine similarity
- add migration and reindex scripts for existing data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e8da61b48324919953c95ac24f35