### PR TITLE
feat(recommendations): add recommendation engine and UI

### DIFF
--- a/packages/operator-admin/src/app/ask-bot/page.tsx
+++ b/packages/operator-admin/src/app/ask-bot/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import AuthGuard from '../../components/AuthGuard';
+import RecommendedQuestions from '../components/RecommendedQuestions';
 import { api } from '../../lib/api';
 import { Button } from '@shadcn/ui/button';
 import { Input } from '@shadcn/ui/input';
@@ -78,6 +79,7 @@ export default function AskBotPage() {
             </div>
           ))}
         </div>
+        <RecommendedQuestions />
         <div className="flex space-x-2">
           <Input
             value={text}

--- a/packages/operator-admin/src/app/components/RecommendedQuestions.tsx
+++ b/packages/operator-admin/src/app/components/RecommendedQuestions.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+import { Button } from '@shadcn/ui/button';
+
+interface Question {
+  id: string;
+  question: string;
+}
+
+export default function RecommendedQuestions() {
+  const [questions, setQuestions] = useState<Question[]>([]);
+
+  useEffect(() => {
+    const userId = localStorage.getItem('user_id');
+    if (!userId) return;
+    api(`/admin/recommendations?user_id=${userId}`)
+      .then((res) => res.json())
+      .then((data) => setQuestions(data.questions || []))
+      .catch(() => setQuestions([]));
+  }, []);
+
+  const sendFeedback = (id: string, liked: boolean) => {
+    const user_id = localStorage.getItem('user_id');
+    if (!user_id) return;
+    api('/admin/recommendations/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, question_id: id, action: liked ? 'feedback_like' : 'feedback_dislike' }),
+    });
+  };
+
+  if (questions.length === 0) return null;
+
+  return (
+    <div className="mt-4">
+      <h2 className="text-xl font-semibold mb-2">Рекомендуемые вопросы</h2>
+      <ul className="space-y-2">
+        {questions.map((q) => (
+          <li key={q.id} className="p-2 border rounded">
+            <div className="mb-2">{q.question}</div>
+            <div className="space-x-2">
+              <Button size="sm" onClick={() => sendFeedback(q.id, true)}>Полезно</Button>
+              <Button size="sm" variant="secondary" onClick={() => sendFeedback(q.id, false)}>Не полезно</Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/api/adminV2.ts
+++ b/src/api/adminV2.ts
@@ -6,6 +6,7 @@ import { env } from '../config/environment';
 import { logger, withRequest } from '../utils/logger';
 import { handleError, asyncHandler } from '../utils/errorHandler';
 import conversationsRouter from './routes/conversations';
+import recommendationsRouter from './routes/recommendations';
 import { authMiddleware, ipAllowlistMiddleware } from '../utils/security';
 
 const app = express();
@@ -62,6 +63,7 @@ app.get('/healthz', (req, res) => {
 // Admin routes with security
 app.use('/admin', adminCors, ipAllowlistMiddleware(), rateLimiter, authMiddleware(['admin', 'editor']));
 app.use('/admin/conversations', conversationsRouter);
+app.use('/admin/recommendations', recommendationsRouter);
 
 // Global error handler
 app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/src/api/routes/recommendations.ts
+++ b/src/api/routes/recommendations.ts
@@ -1,0 +1,39 @@
+import express from 'express';
+import { z } from 'zod';
+import { validateQuery, validateBody } from '../middleware/validation';
+import { asyncHandler } from '../../utils/errorHandler';
+import { getRecommendations, logInteraction } from '../../recommendations/engine';
+
+const router = express.Router();
+
+const recommendQuerySchema = z.object({
+  user_id: z.string().uuid(),
+  limit: z.coerce.number().min(1).max(20).default(5),
+});
+
+const logSchema = z.object({
+  user_id: z.string().uuid(),
+  question_id: z.string().uuid(),
+  action: z.enum(['view', 'answer', 'feedback_like', 'feedback_dislike']),
+});
+
+router.get(
+  '/',
+  validateQuery(recommendQuerySchema),
+  asyncHandler(async (req: express.Request, res: express.Response) => {
+    const { user_id, limit } = req.query as any;
+    const questions = await getRecommendations(user_id, limit);
+    res.json({ questions });
+  })
+);
+
+router.post(
+  '/log',
+  validateBody(logSchema),
+  asyncHandler(async (req: express.Request, res: express.Response) => {
+    await logInteraction(req.body);
+    res.json({ ok: true });
+  })
+);
+
+export default router;

--- a/src/recommendations/engine.ts
+++ b/src/recommendations/engine.ts
@@ -1,0 +1,51 @@
+import { supabaseService } from '../database/connection';
+
+export type InteractionType = 'view' | 'answer' | 'feedback_like' | 'feedback_dislike';
+
+interface Interaction {
+  user_id: string;
+  question_id: string;
+  action: InteractionType;
+}
+
+export async function logInteraction(interaction: Interaction) {
+  const { error } = await supabaseService.from('user_interactions').insert({
+    user_id: interaction.user_id,
+    question_id: interaction.question_id,
+    action: interaction.action,
+  });
+  if (error) throw error;
+}
+
+export async function getRecommendations(userId: string, limit = 5) {
+  const { data: interactions, error } = await supabaseService
+    .from('user_interactions')
+    .select('user_id, question_id');
+  if (error || !interactions) return [];
+
+  const seen = new Set(
+    interactions.filter((i) => i.user_id === userId).map((i) => i.question_id)
+  );
+
+  const counts = new Map<string, number>();
+  for (const row of interactions) {
+    if (row.user_id === userId) continue;
+    counts.set(row.question_id, (counts.get(row.question_id) || 0) + 1);
+  }
+
+  const candidates = Array.from(counts.entries())
+    .filter(([id]) => !seen.has(id))
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => id);
+
+  if (candidates.length === 0) return [];
+
+  const { data: questions } = await supabaseService
+    .from('faq_questions')
+    .select('id, question')
+    .in('id', candidates);
+  return questions || [];
+}
+
+export default { logInteraction, getRecommendations };

--- a/supabase/migrations/20250830130000_add_user_interactions.sql
+++ b/supabase/migrations/20250830130000_add_user_interactions.sql
@@ -1,0 +1,10 @@
+create table if not exists user_interactions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  question_id uuid not null references faq_questions(id),
+  action text check (action in ('view','answer','feedback_like','feedback_dislike')),
+  created_at timestamptz default now()
+);
+
+create index if not exists user_interactions_user_idx on user_interactions(user_id);
+create index if not exists user_interactions_question_idx on user_interactions(question_id);


### PR DESCRIPTION
## Summary
- add Supabase-driven recommendation engine and API
- log user interactions with new table
- show recommended questions with feedback in admin UI

## Testing
- `npm test`
- `npm test -w packages/operator-admin`

------
https://chatgpt.com/codex/tasks/task_e_6898ee65ffd88324bd1ef82b33067da1