### PR TITLE
feat(backend): await http shutdown

### DIFF
--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -17,8 +17,15 @@ const server = app.listen(port, () => console.log(`API on :${port}`));
 const shutdown = async () => {
   console.log('graceful shutdown...');
   server.closeAllConnections?.();
-  server.close(() => console.log('http closed'));
-  try { await pool.end?.(); } catch {}
+  await new Promise<void>((resolve) =>
+    server.close(() => {
+      console.log('http closed');
+      resolve();
+    })
+  );
+  try {
+    await pool.end?.();
+  } catch {}
   process.exit(0);
 };
 process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary
- await HTTP server to close before terminating

## Testing
- `npm test -w packages/backend`
- `npm run build -w packages/backend` *(fails: Could not find a declaration file for module 'zod')*


------
https://chatgpt.com/codex/tasks/task_e_6899072d23f083249f7fad3a24d52998