### PR TITLE
chore: include root tsconfig in backend build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ COPY --from=backend_deps /app/node_modules ./node_modules
 COPY packages/shared ./packages/shared
 COPY packages/backend ./packages/backend
 
+# важно: tsc в пакетах делает extends на корневой tsconfig.base.json
+# скопируй корневые TS-конфиги в образ (только для времени сборки)
+COPY tsconfig*.json ./
+
 # важно: сначала собрать shared, затем backend
 RUN npm --prefix packages/shared run build
 RUN npm --prefix packages/backend run build


### PR DESCRIPTION
## Summary
- copy root tsconfig files into backend build stage

## Testing
- `npm test`
- `docker build . --target backend_build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6899f96c1bb0832487b2ba0489730167