### PR TITLE
refactor: load dotenv-safe only during development

### DIFF
--- a/packages/backend/src/http/loadEnv.ts
+++ b/packages/backend/src/http/loadEnv.ts
@@ -1,0 +1,9 @@
+import path from "node:path";
+import { config } from "dotenv-safe";
+
+// Load environment variables from `.env` using dotenv-safe.
+// `.env.example` ensures required variables are defined.
+config({
+  allowEmptyValues: false,
+  example: path.resolve(process.cwd(), ".env.example"),
+});

--- a/packages/backend/src/http/main.ts
+++ b/packages/backend/src/http/main.ts
@@ -1,13 +1,7 @@
-import path from "node:path";
-
-// Load dotenv-safe only outside production. In production, variables come from the
-// environment and `.env.example` isn't needed.
+// Load environment variables from `.env` in non-production environments.
+// This dynamic import avoids bundling dev-only dependencies in production.
 if (process.env.NODE_ENV !== "production") {
-  const { config } = await import("dotenv-safe");
-  config({
-    allowEmptyValues: false,
-    example: path.resolve(process.cwd(), ".env.example"),
-  });
+  await import("./loadEnv.js");
 }
 
 import { Pool } from "pg";


### PR DESCRIPTION
## Summary
- avoid bundling `dotenv-safe` in production by dynamically importing a dev-only env loader
- extract environment bootstrapping into `loadEnv.ts`

## Testing
- `npm run -w packages/backend build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a345153a8832498248f967a30b62d