### PR TITLE
fix: include .env example in docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN npm ci --omit=dev -w packages/shared -w packages/backend --ignore-scripts
 # копируем билд-артефакты
 COPY --from=backend_build /app/packages/shared/dist   ./packages/shared/dist
 COPY --from=backend_build /app/packages/backend/dist ./packages/backend/dist
+COPY .env.example ./
 
 # без root
 RUN chown -R node:node /app


### PR DESCRIPTION
## Summary
- copy `.env.example` into runtime Docker image so dotenv-safe can validate env vars during deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3708f3608324a4663ca0650f5fc1