### PR TITLE
refactor(backend): disable dotenv-safe in production, centralize env preload and validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ RUN npm ci --omit=dev -w packages/shared -w packages/backend --ignore-scripts
 # копируем билд-артефакты
 COPY --from=backend_build /app/packages/shared/dist   ./packages/shared/dist
 COPY --from=backend_build /app/packages/backend/dist ./packages/backend/dist
-COPY .env.example ./
 
 # без root
 RUN chown -R node:node /app

--- a/packages/backend/src/config/dotenv.ts
+++ b/packages/backend/src/config/dotenv.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+
+/**
+ * Загружает .env только в dev/test. В production ничего не делает.
+ * Вызывать ПЕРЕД тем, как импортировать остальной код приложения.
+ */
+export async function preloadEnv(): Promise<void> {
+  if (process.env.NODE_ENV !== "production") {
+    const { config } = await import("dotenv-safe");
+    config({
+      allowEmptyValues: false,
+      example: path.resolve(process.cwd(), ".env.example"),
+    });
+  }
+}

--- a/packages/backend/src/http/loadEnv.ts
+++ b/packages/backend/src/http/loadEnv.ts
@@ -1,9 +1,31 @@
-import path from "node:path";
-import { config } from "dotenv-safe";
+import { z } from "zod";
 
-// Load environment variables from `.env` using dotenv-safe.
-// `.env.example` ensures required variables are defined.
-config({
-  allowEmptyValues: false,
-  example: path.resolve(process.cwd(), ".env.example"),
-});
+// Оставь в схеме ТОЛЬКО реально необходимые ключи для запуска бэка.
+// Минимум: DATABASE_URL, ENCRYPTION_KEY_BASE64. Остальные по мере надобности.
+const EnvSchema = z
+  .object({
+    NODE_ENV: z.string().default("production"),
+    DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+    ENCRYPTION_KEY_BASE64: z
+      .string()
+      .min(1, "ENCRYPTION_KEY_BASE64 is required"),
+  })
+  .passthrough();
+
+type Env = z.infer<typeof EnvSchema>;
+
+let cached: Env | null = null;
+
+/** Валидирует process.env один раз и кэширует результат. */
+export function getEnv(): Env {
+  if (cached) return cached;
+  const parsed = EnvSchema.safeParse(process.env);
+  if (!parsed.success) {
+    const msg = parsed.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    throw new Error(`Invalid environment: ${msg}`);
+  }
+  cached = parsed.data;
+  return cached;
+}

--- a/packages/backend/src/http/main.ts
+++ b/packages/backend/src/http/main.ts
@@ -1,33 +1,21 @@
-// Load environment variables from `.env` in non-production environments.
-// This dynamic import avoids bundling dev-only dependencies in production.
-if (process.env.NODE_ENV !== "production") {
-  await import("./loadEnv.js");
-}
+import { preloadEnv } from "../config/dotenv.js";
 
-import { Pool } from "pg";
-import { buildServer } from "./server.js";
-import { PgUserRepo } from "../modules/users/infra/PgUserRepo.js";
+// 1) Сначала подгружаем .env в dev/test (в production — noop)
+await preloadEnv();
 
-// ---------- чтение окружения ----------
+// 2) Теперь динамически импортируем остальной код,
+// чтобы он выполнялся уже после загрузки env.
+const { getEnv } = await import("./loadEnv.js");
+const { buildServer } = await import("./server.js");
+const { Pool } = await import("pg");
+const { PgUserRepo } = await import("../modules/users/infra/PgUserRepo.js");
+
+// 3) Читаем окружение (с валидацией)
+const env = getEnv();
 const PORT = Number(process.env.PORT ?? 3000);
-const DATABASE_URL = process.env.DATABASE_URL;
-const ENCRYPTION_KEY_BASE64 = process.env.ENCRYPTION_KEY_BASE64;
-
-if (!DATABASE_URL) {
-  throw new Error("DATABASE_URL is required");
-}
-if (!ENCRYPTION_KEY_BASE64) {
-  throw new Error("ENCRYPTION_KEY_BASE64 is required");
-}
-
-// ---------- инфраструктура ----------
-const pool = new Pool({ connectionString: DATABASE_URL });
+const pool = new Pool({ connectionString: env.DATABASE_URL });
 const userRepo = new PgUserRepo(pool);
 
-// ---------- запуск HTTP ----------
+// 4) Запуск сервера
 const app = await buildServer({ userRepo });
-
-app.listen({ port: PORT, host: "0.0.0.0" }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+await app.listen({ port: PORT, host: "0.0.0.0" });


### PR DESCRIPTION
## Summary
- lazily preload env vars via dotenv-safe only outside production
- validate env once and cache the result
- load env before importing backend modules; drop .env.example from runtime Docker stage

## Testing
- `npm run build -w packages/backend`
- `npm test -w packages/backend`
- `PORT=3000 NODE_ENV=production DATABASE_URL=postgres://postgres:password@localhost:5432/postgres ENCRYPTION_KEY_BASE64=Zm9vYmFy node packages/backend/dist/http/main.js & curl -s http://127.0.0.1:3000/api/health`


------
https://chatgpt.com/codex/tasks/task_e_689a3db09a548324aebdb8febb327366