### PR TITLE
feat: add rag pipeline and postgres plugin

### DIFF
--- a/packages/backend/src/app/pipeline/ragAnswer.ts
+++ b/packages/backend/src/app/pipeline/ragAnswer.ts
@@ -1,0 +1,115 @@
+import type { FastifyInstance } from "fastify";
+import { findExact } from "../../faq/store.js";
+import { findFuzzy } from "../../faq/fuzzy.js";
+import type { SearchSource } from "../../domain/bot/types.js";
+import { refineDraft } from "../llm/llmRefine.js";
+
+interface RagParams {
+  text: string;
+  lang?: string;
+}
+
+export async function ragAnswer(app: FastifyInstance, params: RagParams) {
+  const { text, lang } = params;
+  const logger = app.log;
+  let start = Date.now();
+
+  const exact = findExact(text);
+  logger.info({
+    stage: "faq_exact",
+    ms: Date.now() - start,
+    hits: exact ? 1 : 0,
+  });
+  if (exact) {
+    return {
+      answer: exact.a,
+      escalate: false,
+      confidence: 1,
+      citations: [] as Array<{ id: string }>,
+    };
+  }
+
+  start = Date.now();
+  const fuzzy = findFuzzy(text);
+  logger.info({
+    stage: "faq_fuzzy",
+    ms: Date.now() - start,
+    hits: fuzzy.hit ? 1 : 0,
+  });
+  if (fuzzy.hit) {
+    return {
+      answer: fuzzy.hit.a,
+      escalate: false,
+      confidence: 0.9,
+      citations: [] as Array<{ id: string }>,
+    };
+  }
+
+  start = Date.now();
+  let sources: SearchSource[] = [];
+  let draft = "";
+  try {
+    const q = await app.pg.query<{ draft?: string; sources?: any }>(
+      "select draft, sources from kb_search_json($1)",
+      [text],
+    );
+    const row = q.rows?.[0];
+    if (row) {
+      draft = typeof row.draft === "string" ? row.draft : "";
+      if (Array.isArray(row.sources)) {
+        sources = row.sources.map((s: any) => ({
+          id: String(s.id),
+          ...(s.title !== undefined ? { title: s.title } : {}),
+          ...(s.url !== undefined ? { url: s.url } : {}),
+          ...(s.snippet !== undefined ? { snippet: s.snippet } : {}),
+          ...(s.score !== undefined ? { score: Number(s.score) } : {}),
+        }));
+      }
+    }
+    logger.info({
+      stage: "kb_search",
+      ms: Date.now() - start,
+      hits: sources.length,
+    });
+  } catch (err: any) {
+    logger.error({ err }, "kb_search failed");
+    logger.info({ stage: "kb_search", ms: Date.now() - start, hits: 0 });
+  }
+
+  const draftText = draft || sources.map((s) => s.snippet ?? "").join("\n");
+  start = Date.now();
+  const result = await refineDraft(
+    { question: text, draft: draftText, sources, lang },
+    {
+      targetLang: lang ?? "ru",
+      minConfidenceToEscalate: Number(
+        process.env.MIN_CONFIDENCE_TO_ESCALATE || 0.55,
+      ),
+    },
+  );
+  logger.info({
+    stage: "refine",
+    ms: Date.now() - start,
+    hits: result.citations.length,
+  });
+
+  try {
+    await app.pg.query(
+      `insert into bot_responses (question, draft, answer, confidence, escalate, lang) values ($1,$2,$3,$4,$5,$6)`,
+      [
+        text,
+        draftText,
+        result.answer,
+        result.confidence,
+        result.escalate,
+        lang ?? "ru",
+      ],
+    );
+  } catch (err: any) {
+    logger.error({ err }, "insert bot_responses failed");
+  }
+
+  return result;
+}
+
+export default ragAnswer;

--- a/packages/backend/src/http/routes/index.ts
+++ b/packages/backend/src/http/routes/index.ts
@@ -1,0 +1,12 @@
+import { FastifyPluginAsync } from "fastify";
+import bot from "./bot.js";
+import adminFeedback from "./admin/feedback.js";
+import adminMetrics from "./admin/metrics.js";
+
+const routes: FastifyPluginAsync = async (app) => {
+  await app.register(bot);
+  await app.register(adminFeedback);
+  await app.register(adminMetrics);
+};
+
+export default routes;

--- a/packages/backend/src/plugins/pg.ts
+++ b/packages/backend/src/plugins/pg.ts
@@ -1,0 +1,14 @@
+import fp from "fastify-plugin";
+import { Pool } from "pg";
+import type { FastifyPluginAsync } from "fastify";
+
+const pgPlugin: FastifyPluginAsync = fp(async (app) => {
+  const connectionString = process.env.DATABASE_URL;
+  const pool = new Pool({ connectionString });
+  app.decorate("pg", pool);
+  app.addHook("onClose", async () => {
+    await pool.end();
+  });
+});
+
+export default pgPlugin;

--- a/packages/backend/src/types/fastify-postgres.d.ts
+++ b/packages/backend/src/types/fastify-postgres.d.ts
@@ -1,12 +1,8 @@
 import "fastify";
-import type { Pool, PoolClient } from "pg";
+import type { Pool } from "pg";
 
 declare module "fastify" {
-	interface FastifyInstance {
-		pg: {
-			pool: Pool;
-			connect(): Promise<PoolClient>;
-			query<T = any>(query: string, values?: any[]): Promise<{ rows: T[] }>;
-		};
-	}
+  interface FastifyInstance {
+    pg: Pool;
+  }
 }


### PR DESCRIPTION
## Summary
- wire postgres plugin and type definitions
- implement RAG answer pipeline with FAQ, KB search, and LLM refinement
- expose Telegram webhook using Fastify with rate limiting

## Testing
- `npm test -w packages/backend`

------
https://chatgpt.com/codex/tasks/task_e_689ba5f8a80c8324a45911576df1c031