### PR TITLE
feat: secure pg pool and db diagnostics

### DIFF
--- a/packages/backend/src/app/pipeline/ragAnswer.ts
+++ b/packages/backend/src/app/pipeline/ragAnswer.ts
@@ -61,13 +61,15 @@ export async function ragAnswer({ text, lang, logger, pg }: RagParams) {
     if (row) {
       draft = typeof row.draft === "string" ? row.draft : "";
       if (Array.isArray(row.sources)) {
-        sources = row.sources.map((s: any) => ({
-          id: String(s.id),
-          ...(s.title !== undefined ? { title: s.title } : {}),
-          ...(s.url !== undefined ? { url: s.url } : {}),
-          ...(s.snippet !== undefined ? { snippet: s.snippet } : {}),
-          ...(s.score !== undefined ? { score: Number(s.score) } : {}),
-        }));
+        sources = row.sources
+          .filter((s: any) => s)
+          .map((s: any) => ({
+            id: String(s.id),
+            ...(s.title !== undefined ? { title: s.title } : {}),
+            ...(s.url !== undefined ? { url: s.url } : {}),
+            ...(s.snippet !== undefined ? { snippet: s.snippet } : {}),
+            ...(s.score !== undefined ? { score: Number(s.score) } : {}),
+          }));
       }
     }
     logger.info({

--- a/packages/backend/src/http/main.ts
+++ b/packages/backend/src/http/main.ts
@@ -53,17 +53,16 @@ export async function createApp(): Promise<FastifyInstance> {
   const bot = new Telegraf(TG_TOKEN);
 
   bot.catch((err, ctx) => {
-    app.log.error({ err, update: ctx.update }, "Telegraf error");
+    app.log.error(
+      { err, tg_chat_id: ctx.chat?.id, tg_type: ctx.updateType },
+      "Telegraf error",
+    );
   });
 
   bot.on("message", async (ctx, next) => {
     try {
-      const chat = (ctx.message as any)?.chat;
       app.log.info(
-        {
-          tg_chat_id: chat?.id,
-          tg_type: (ctx.message as any)?.type || "message",
-        },
+        { tg_chat_id: ctx.chat?.id, tg_type: ctx.updateType },
         "tg update received",
       );
     } catch {}

--- a/packages/backend/src/http/routes/admin/db.ts
+++ b/packages/backend/src/http/routes/admin/db.ts
@@ -1,0 +1,38 @@
+import { FastifyPluginAsync } from "fastify";
+
+function assertAdmin(req: any) {
+  const hdr = (req.headers["authorization"] as string) || "";
+  const bearer = hdr.startsWith("Bearer ") ? hdr.slice(7) : undefined;
+  const x = (req.headers["x-admin-token"] as string) || bearer;
+  const tokens = (process.env.ADMIN_API_TOKENS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!x || !tokens.includes(x)) {
+    const err: any = new Error("unauthorized");
+    err.statusCode = 401;
+    throw err;
+  }
+}
+
+const plugin: FastifyPluginAsync = async (app) => {
+  app.get("/api/admin/db/ping", async (req, reply) => {
+    try {
+      assertAdmin(req);
+    } catch {
+      reply.code(401);
+      return { error: "Unauthorized" };
+    }
+
+    try {
+      const q = await app.pg.query<{ now: string }>("select now() as now");
+      return { ok: true, now: q.rows[0].now };
+    } catch (err) {
+      req.log.error({ err }, "db ping failed");
+      reply.code(500);
+      return { error: "InternalError" };
+    }
+  });
+};
+
+export default plugin;

--- a/packages/backend/src/http/routes/index.ts
+++ b/packages/backend/src/http/routes/index.ts
@@ -2,11 +2,13 @@ import { FastifyPluginAsync } from "fastify";
 import bot from "./bot.js";
 import adminFeedback from "./admin/feedback.js";
 import adminMetrics from "./admin/metrics.js";
+import adminDb from "./admin/db.js";
 
 const routes: FastifyPluginAsync = async (app) => {
   await app.register(bot);
   await app.register(adminFeedback);
   await app.register(adminMetrics);
+  await app.register(adminDb);
 };
 
 export default routes;

--- a/packages/backend/src/plugins/pg.ts
+++ b/packages/backend/src/plugins/pg.ts
@@ -8,7 +8,42 @@ import {
 } from "pg";
 
 const pgPlugin: FastifyPluginAsync = async (app) => {
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const connectionString = process.env.DATABASE_URL;
+  const url = connectionString ? new URL(connectionString) : undefined;
+  const isSupabase = url ? url.hostname.endsWith(".supabase.com") : false;
+  const sslMode = (
+    process.env.PGSSLMODE || (isSupabase ? "require" : "disable")
+  ).toLowerCase();
+  const ssl =
+    sslMode === "disable"
+      ? false
+      : { rejectUnauthorized: sslMode !== "no-verify" };
+
+  const pool = new Pool({
+    connectionString,
+    ssl,
+    max: 10,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+
+  pool.on("connect", (client) => {
+    client
+      .query("set statement_timeout=15000")
+      .catch((err) => app.log.error({ err }, "statement_timeout set failed"));
+    client
+      .query("set idle_in_transaction_session_timeout=15000")
+      .catch((err) =>
+        app.log.error(
+          { err },
+          "idle_in_transaction_session_timeout set failed",
+        ),
+      );
+  });
+
+  pool.on("error", (err) => {
+    app.log.error({ err }, "pg pool error");
+  });
 
   app.decorate("pg", {
     pool,


### PR DESCRIPTION
## Summary
- harden PG pool with SSL defaults, timeouts and quiet error logging
- sanitize Telegram update logging and expose admin DB ping endpoint
- filter undefined values in RAG sources

## Testing
- `npm test`
- `npm run lint -w packages/backend`


------
https://chatgpt.com/codex/tasks/task_e_689bad066d6c8324bd0f8ea4e99033b1